### PR TITLE
Fixes windows masterless installation

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -409,7 +409,7 @@ module Beaker
 
               # 1 since no certificate found and waitforcert disabled
               acceptable_exit_codes = 1
-              setup_defaults_and_config_helper_on(host, master, acceptable_exit_codes)
+              setup_defaults_and_config_helper_on(host, master, acceptable_exit_codes) unless masterless
             else
               # We only need answers if we're using the classic installer
               version = host['pe_ver'] || opts[:pe_ver]

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -409,7 +409,12 @@ module Beaker
 
               # 1 since no certificate found and waitforcert disabled
               acceptable_exit_codes = 1
-              setup_defaults_and_config_helper_on(host, master, acceptable_exit_codes) unless masterless
+              if masterless
+                configure_type_defaults_on(host)
+                on host, puppet_agent('-t'), :acceptable_exit_codes => acceptable_exit_codes
+              else
+                setup_defaults_and_config_helper_on(host, master, acceptable_exit_codes)
+              end
             else
               # We only need answers if we're using the classic installer
               version = host['pe_ver'] || opts[:pe_ver]


### PR DESCRIPTION
Setting up a masterless windows client would fail with the following error:

Exited: 1
/usr/local/rvm/gems/ruby-2.2.1/gems/beaker-2.37.0/lib/beaker/host.rb:330:in `exec': Host 'sxrwjhkia9gzo03' exited with 1 running: (Beaker::Host::CommandFailure)
 cmd.exe /c puppet config set server
Last 10 lines of output were:
        Error: puppet config set takes 2 arguments, but you gave 1
        Error: Try 'puppet help config set' for usage

As far as I could see this error is caused by the 'setup_defaults_and_config_helper_on' function which tries to set the master configuration setting in puppet.conf. But since there is no master varaible available this failes.

This patch should fix that by only calling setup_defaults_and_config_helper_on whern we're not doing a masterless installation.