### PR TITLE
(PE-14271) Wire beaker-pe for meep

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -443,8 +443,15 @@ module Beaker
               end
             end
 
-            # On each agent, we ensure the certificate is signed then shut down the agent
-            sign_certificate_for(host) unless masterless
+            # On each agent, we ensure the certificate is signed
+            if !masterless
+              if [master, database, dashboard].include?(host) && use_meep?(host['pe_ver'])
+                # This step is not necessary for the core pe nodes when using meep
+              else
+                sign_certificate_for(host)
+              end
+            end
+            # then shut down the agent
             stop_agent_on(host)
           end
 

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -448,11 +448,15 @@ module Beaker
               if [master, database, dashboard].include?(host) && use_meep?(host['pe_ver'])
                 # This step is not necessary for the core pe nodes when using meep
               else
-                sign_certificate_for(host)
+                step "Sign certificate for #{host}" do
+                  sign_certificate_for(host)
+                end
               end
             end
             # then shut down the agent
-            stop_agent_on(host)
+            step "Shutting down agent for #{host}" do
+              stop_agent_on(host)
+            end
           end
 
           unless masterless

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -736,9 +736,8 @@ module Beaker
         #                    The host object must have the 'working_dir', 'dist' and 'pe_installer' field set correctly.
         # @api private
         def higgs_installer_cmd host
-
-          "cd #{host['working_dir']}/#{host['dist']} ; nohup ./#{host['pe_installer']} <<<Y > #{host['higgs_file']} 2>&1 &"
-
+          higgs_answer = host['pe_installer_type'] == 'meep' ? '1' : 'Y'
+          "cd #{host['working_dir']}/#{host['dist']} ; nohup ./#{host['pe_installer']} <<<#{higgs_answer} > #{host['higgs_file']} 2>&1 &"
         end
 
         #Perform a Puppet Enterprise Higgs install up until web browser interaction is required, runs on linux hosts only.
@@ -771,6 +770,8 @@ module Beaker
           fetch_pe([host], opts)
 
           host['higgs_file'] = "higgs_#{File.basename(host['working_dir'])}.log"
+
+          prepare_host_installer_options(host)
           on host, higgs_installer_cmd(host), opts
 
           #wait for output to host['higgs_file']

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -718,6 +718,7 @@ module Beaker
         #  prep_host_for_upgrade(master, {}, "http://neptune.puppetlabs.lan/3.0/ci-ready/")
         def prep_host_for_upgrade(host, opts={}, path='')
           host['pe_dir'] = host['pe_upgrade_dir'] || path
+          host['previous_pe_ver'] = host['pe_ver']
           if host['platform'] =~ /windows/
             host['pe_ver'] = host['pe_upgrade_ver'] || opts['pe_upgrade_ver'] ||
               Options::PEVersionScraper.load_pe_version(host['pe_dir'], opts[:pe_version_file_win])

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -550,10 +550,12 @@ module Beaker
         # @param [Hash] opts The Beaker options hash
         # @return [BeakerAnswers::Answers] the generated answers object
         def generate_installer_conf_file_for(host, hosts, opts)
-           answers = BeakerAnswers::Answers.create(opts[:pe_ver] || host['pe_ver'], hosts, opts)
-           configuration = answers.answer_string(host)
-           create_remote_file(host, host['pe_installer_conf_file'], configuration)
-           answers
+          format = host['pe_installer_type'] == 'meep' ? :hiera : :bash
+          beaker_opts = opts.merge(:format => format )
+          answers = BeakerAnswers::Answers.create(opts[:pe_ver] || host['pe_ver'], hosts, beaker_opts)
+          configuration = answers.installer_configuration_string(host)
+          create_remote_file(host, host['pe_installer_conf_file'], configuration)
+          answers
         end
 
         # Builds the agent_only and not_agent_only arrays needed for installation.

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -400,12 +400,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :stop_agent_on ).and_return( true )
       allow( subject ).to receive( :sleep_until_puppetdb_started ).and_return( true )
       allow( subject ).to receive( :max_version ).with(anything, '3.8').and_return('3.0')
-      allow( subject ).to receive( :version_is_less ).with('3.0', '4.0').and_return( true )
-      allow( subject ).to receive( :version_is_less ).with('3.0', '3.4').and_return( true )
-      allow( subject ).to receive( :version_is_less ).with('3.0', '3.0').and_return( false )
-      allow( subject ).to receive( :version_is_less ).with('3.0', '3.99').and_return( true )
-      allow( subject ).to receive( :version_is_less ).with('3.99', '3.0').and_return( false )
-      allow( subject ).to receive( :version_is_less ).with('3.0', '2016.1.0').and_return( true )
       allow( subject ).to receive( :wait_for_host_in_dashboard ).and_return( true )
       allow( subject ).to receive( :puppet_agent ) do |arg|
         "puppet agent #{arg}"
@@ -476,9 +470,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :create_remote_file ).and_return( true )
       allow( subject ).to receive( :stop_agent_on ).and_return( true )
       allow( subject ).to receive( :max_version ).with(['3.0'], '3.8').and_return('3.0')
-      allow( subject ).to receive( :version_is_less ).with('3.99', '3.0').and_return( false )
-      allow( subject ).to receive( :version_is_less ).with(anything, '3.2.0').exactly(hosts.length + 1).times.and_return( false )
-      allow( subject ).to receive( :version_is_less ).with(anything, '4.0').exactly(hosts.length + 1).times.and_return( true )
 
       expect( subject ).to receive( :on ).with( hosts[0], /puppet-enterprise-installer/ ).once
       expect( subject ).to receive( :create_remote_file ).with( hosts[0], /answers/, /q/ ).once
@@ -514,13 +505,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :stop_agent_on ).and_return( true )
       allow( subject ).to receive( :sleep_until_puppetdb_started ).and_return( true )
       allow( subject ).to receive( :max_version ).with(anything, '3.8').and_return('4.0')
-      allow( subject ).to receive( :version_is_less ).with('4.0', '4.0').and_return( false )
-      allow( subject ).to receive( :version_is_less ).with('4.0', '3.4').and_return( false )
-      allow( subject ).to receive( :version_is_less ).with('4.0', '3.0').and_return( false )
-      allow( subject ).to receive( :version_is_less ).with('3.99', '4.0').and_return( true )
-      allow( subject ).to receive( :version_is_less ).with('4.0', '2016.1.0').and_return( true )
-      # pe_ver is only set on the hosts for this test, not the opt
-      allow( subject ).to receive( :version_is_less ).with('4.0', '3.99').and_return( true )
       allow( subject ).to receive( :wait_for_host_in_dashboard ).and_return( true )
       allow( subject ).to receive( :puppet_agent ) do |arg|
         "puppet agent #{arg}"
@@ -578,14 +562,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :stop_agent_on ).and_return( true )
       allow( subject ).to receive( :sleep_until_puppetdb_started ).and_return( true )
       allow( subject ).to receive( :max_version ).with(anything, '3.8').and_return('4.0')
-      allow( subject ).to receive( :version_is_less ).with('4.0', '4.0').and_return( false )
-      allow( subject ).to receive( :version_is_less ).with('4.0', '3.4').and_return( false )
-      allow( subject ).to receive( :version_is_less ).with('4.0', '3.0').and_return( false )
-      allow( subject ).to receive( :version_is_less ).with('3.99', '4.0').and_return( true )
-      allow( subject ).to receive( :version_is_less ).with('3.8', '4.0').and_return( true )
-      allow( subject ).to receive( :version_is_less ).with('4.0', '2016.1.0').and_return( true )
-      # pe_ver is only set on the hosts for this test, not the opt
-      allow( subject ).to receive( :version_is_less ).with('4.0', '3.99').and_return( true )
       allow( subject ).to receive( :wait_for_host_in_dashboard ).and_return( true )
       allow( subject ).to receive( :puppet_agent ) do |arg|
         "puppet agent #{arg}"
@@ -640,14 +616,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :stop_agent_on ).and_return( true )
       allow( subject ).to receive( :sleep_until_puppetdb_started ).and_return( true )
       allow( subject ).to receive( :max_version ).with(anything, '3.8').and_return('4.0')
-      allow( subject ).to receive( :version_is_less ).with('4.0', '4.0').and_return( false )
-      allow( subject ).to receive( :version_is_less ).with('4.0', '3.4').and_return( false )
-      allow( subject ).to receive( :version_is_less ).with('4.0', '3.0').and_return( false )
-      allow( subject ).to receive( :version_is_less ).with('3.99', '4.0').and_return( true )
-      allow( subject ).to receive( :version_is_less ).with('3.8', '4.0').and_return( true )
-      allow( subject ).to receive( :version_is_less ).with('4.0', '2016.1.0').and_return( true )
-      # pe_ver is only set on the hosts for this test, not the opt
-      allow( subject ).to receive( :version_is_less ).with('4.0', '3.99').and_return( true )
       allow( subject ).to receive( :wait_for_host_in_dashboard ).and_return( true )
       allow( subject ).to receive( :puppet_agent ) do |arg|
         "puppet agent #{arg}"

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -324,8 +324,30 @@ describe ClassMixedWithDSLInstallUtils do
   end
 
   describe 'generate_installer_conf_file_for' do
-    it 'generates a legacy answer file if host["pe_installer_type"]=="legacy"'
-    it 'generates a meep config file if host["pe_installer_type"]=="meep"'
+    let(:master) { hosts.first }
+
+    it 'generates a legacy answer file if host["pe_installer_type"]=="legacy"' do
+      master['pe_installer_conf_file'] = '/tmp/answers'
+      master['pe_installer_type'] = 'legacy'
+      expect(subject).to receive(:create_remote_file).with(
+        master,
+        '/tmp/answers',
+        %r{q_install=y.*q_puppetmaster_certname=#{master}}m
+      )
+      subject.generate_installer_conf_file_for(master, hosts, opts)
+    end
+
+    it 'generates a meep config file if host["pe_installer_type"]=="meep"' do
+      master['pe_installer_conf_file'] = '/tmp/pe.conf'
+      master['pe_installer_type'] = 'meep'
+      master['pe_ver'] = '2016.2.0'
+      expect(subject).to receive(:create_remote_file).with(
+        master,
+        '/tmp/pe.conf',
+        %r{\{.*"puppet_enterprise::puppet_master_host": "#{master}"}m
+      )
+      subject.generate_installer_conf_file_for(master, hosts, opts)
+    end
   end
 
   describe 'fetch_pe' do

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -406,7 +406,7 @@ describe ClassMixedWithDSLInstallUtils do
       expect(subject).to receive(:create_remote_file).with(
         master,
         '/tmp/pe.conf',
-        %r{\{.*"puppet_enterprise::puppet_master_host": "#{master}"}m
+        %r{\{.*"puppet_enterprise::puppet_master_host": "#{master.hostname}"}m
       )
       subject.generate_installer_conf_file_for(master, hosts, opts)
     end

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -458,7 +458,6 @@ describe ClassMixedWithDSLInstallUtils do
       end
       allow( subject ).to receive( :on ).and_return( true )
 
-      path = unixhost['pe_dir']
       filename = "#{ unixhost['dist'] }"
       extension = '.tar'
       expect( subject ).to receive( :fetch_and_push_pe ).with( unixhost, anything, filename, extension ).once
@@ -483,7 +482,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :link_exists? ).and_return( true ) #is a tar.gz
       allow( subject ).to receive( :on ).and_return( true )
 
-      path = unixhost['pe_dir']
       filename = "#{ unixhost['dist'] }"
       extension = '.tar.gz'
       expect( subject ).to receive( :fetch_and_push_pe ).with( unixhost, anything, filename, extension ).once
@@ -918,7 +916,6 @@ describe ClassMixedWithDSLInstallUtils do
       the_hosts = [ hosts[0].dup, hosts[1].dup, hosts[2].dup ]
       allow( subject ).to receive( :hosts ).and_return( the_hosts )
       allow( subject ).to receive( :options ).and_return( {} )
-      version = version_win = '2.8'
       path = "/path/to/upgradepkg"
       expect( subject ).to receive( :do_install ).with( the_hosts, {:type=>:upgrade, :set_console_password=>true} )
       subject.upgrade_pe( path )
@@ -933,7 +930,6 @@ describe ClassMixedWithDSLInstallUtils do
       the_hosts = [ hosts[0].dup, hosts[1].dup, hosts[2].dup ]
       allow( subject ).to receive( :hosts ).and_return( the_hosts )
       allow( subject ).to receive( :options ).and_return( {} )
-      version = version_win = '3.1'
       path = "/path/to/upgradepkg"
       expect( subject ).to receive( :do_install ).with( the_hosts, {:type=>:upgrade, :set_console_password=>true} )
       subject.upgrade_pe( path )
@@ -948,7 +944,6 @@ describe ClassMixedWithDSLInstallUtils do
       the_hosts = [ hosts[0].dup, hosts[1].dup, hosts[2].dup ]
       allow( subject ).to receive( :hosts ).and_return( the_hosts )
       allow( subject ).to receive( :options ).and_return( {} )
-      version = version_win = '2.8'
       path = "/path/to/upgradepkg"
       expect( subject ).to receive( :do_install ).with( the_hosts, {:type=>:upgrade, :set_console_password=>true} )
       subject.upgrade_pe( path )
@@ -962,7 +957,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( Beaker::Options::PEVersionScraper ).to receive( :load_pe_version_win ).and_return( '3.1' )
       allow( subject ).to receive( :hosts ).and_return( hosts )
       allow( subject ).to receive( :sorted_hosts ).and_return( [hosts[0]] )
-      version = version_win = '3.1'
       path = "/path/to/upgradepkg"
       expect( subject ).to receive( :do_install ).with( [hosts[0]], {:type=>:upgrade, :set_console_password=>true} )
       subject.upgrade_pe_on(hosts[0], {}, path)

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -197,22 +197,22 @@ describe ClassMixedWithDSLInstallUtils do
     end
 
     it 'generates a unix PE frictionless install command for a unix host with role "frictionless"' do
-      allow( subject ).to receive( :version_is_less ).and_return( false )
       allow( subject ).to receive( :master ).and_return( 'testmaster' )
       the_host = unixhost.dup
+      the_host['pe_ver'] = '3.8.0'
       the_host['pe_installer'] = 'puppet-enterprise-installer'
       the_host['roles'] = ['frictionless']
-      expect( subject.installer_cmd( the_host, {} ) ).to be ===  "cd /tmp && curl --tlsv1 -kO https://testmaster:8140/packages/3.0/install.bash && bash install.bash"
+      expect( subject.installer_cmd( the_host, {} ) ).to be ===  "cd /tmp && curl --tlsv1 -kO https://testmaster:8140/packages/3.8.0/install.bash && bash install.bash"
     end
 
     it 'generates a unix PE frictionless install command for a unix host with role "frictionless" and "frictionless_options"' do
-      allow( subject ).to receive( :version_is_less ).and_return( false )
       allow( subject ).to receive( :master ).and_return( 'testmaster' )
       the_host = unixhost.dup
+      the_host['pe_ver'] = '3.8.0'
       the_host['pe_installer'] = 'puppet-enterprise-installer'
       the_host['roles'] = ['frictionless']
       the_host['frictionless_options'] = { 'main' => { 'dns_alt_names' => 'puppet' } }
-      expect( subject.installer_cmd( the_host, {} ) ).to be ===  "cd /tmp && curl --tlsv1 -kO https://testmaster:8140/packages/3.0/install.bash && bash install.bash main:dns_alt_names=puppet"
+      expect( subject.installer_cmd( the_host, {} ) ).to be ===  "cd /tmp && curl --tlsv1 -kO https://testmaster:8140/packages/3.8.0/install.bash && bash install.bash main:dns_alt_names=puppet"
     end
 
     it 'generates a osx PE install command for a osx host' do
@@ -243,13 +243,13 @@ describe ClassMixedWithDSLInstallUtils do
     end
 
     it 'generates a unix PE frictionless install command in verbose for a unix host with role "frictionless" and pe_debug is enabled' do
-      allow( subject ).to receive( :version_is_less ).and_return( false )
       allow( subject ).to receive( :master ).and_return( 'testmaster' )
       the_host = unixhost.dup
+      the_host['pe_ver'] = '3.8.0'
       the_host['pe_installer'] = 'puppet-enterprise-installer'
       the_host['roles'] = ['frictionless']
       the_host[:pe_debug] = true
-      expect( subject.installer_cmd( the_host, {} ) ).to be === "cd /tmp && curl --tlsv1 -kO https://testmaster:8140/packages/3.0/install.bash && bash -x install.bash"
+      expect( subject.installer_cmd( the_host, {} ) ).to be === "cd /tmp && curl --tlsv1 -kO https://testmaster:8140/packages/3.8.0/install.bash && bash -x install.bash"
     end
 
   end
@@ -386,7 +386,6 @@ describe ClassMixedWithDSLInstallUtils do
 
       expect( subject).to_not receive(:scp_to)
       expect( subject).to_not receive(:on)
-      allow( subject ).to receive(:version_is_less).with('3.2.0', '3.2.0').and_return(false)
       subject.fetch_pe( [unixhost], {} )
     end
   end
@@ -762,8 +761,6 @@ describe ClassMixedWithDSLInstallUtils do
       the_hosts = [ hosts[0].dup, hosts[1].dup, hosts[2].dup ]
       allow( subject ).to receive( :hosts ).and_return( the_hosts )
       allow( subject ).to receive( :options ).and_return( {} )
-      allow( subject ).to receive( :version_is_less ).with('3.0', '3.4.0').and_return( true )
-      allow( subject ).to receive( :version_is_less ).with('2.8', '3.0').and_return( true )
       version = version_win = '2.8'
       path = "/path/to/upgradepkg"
       expect( subject ).to receive( :do_install ).with( the_hosts, {:type=>:upgrade, :set_console_password=>true} )
@@ -779,8 +776,6 @@ describe ClassMixedWithDSLInstallUtils do
       the_hosts = [ hosts[0].dup, hosts[1].dup, hosts[2].dup ]
       allow( subject ).to receive( :hosts ).and_return( the_hosts )
       allow( subject ).to receive( :options ).and_return( {} )
-      allow( subject ).to receive( :version_is_less ).with('3.0', '3.4.0').and_return( true )
-      allow( subject ).to receive( :version_is_less ).with('3.1', '3.0').and_return( false )
       version = version_win = '3.1'
       path = "/path/to/upgradepkg"
       expect( subject ).to receive( :do_install ).with( the_hosts, {:type=>:upgrade, :set_console_password=>true} )
@@ -796,8 +791,6 @@ describe ClassMixedWithDSLInstallUtils do
       the_hosts = [ hosts[0].dup, hosts[1].dup, hosts[2].dup ]
       allow( subject ).to receive( :hosts ).and_return( the_hosts )
       allow( subject ).to receive( :options ).and_return( {} )
-      allow( subject ).to receive( :version_is_less ).with('3.0', '3.4.0').and_return( true )
-      allow( subject ).to receive( :version_is_less ).with('2.8', '3.0').and_return( true )
       version = version_win = '2.8'
       path = "/path/to/upgradepkg"
       expect( subject ).to receive( :do_install ).with( the_hosts, {:type=>:upgrade, :set_console_password=>true} )
@@ -811,8 +804,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( Beaker::Options::PEVersionScraper ).to receive( :load_pe_version ).and_return( '3.1' )
       allow( Beaker::Options::PEVersionScraper ).to receive( :load_pe_version_win ).and_return( '3.1' )
       allow( subject ).to receive( :hosts ).and_return( hosts )
-      allow( subject ).to receive( :version_is_less ).with('3.0', '3.4.0').and_return( true )
-      allow( subject ).to receive( :version_is_less ).with('3.1', '3.0').and_return( false )
       allow( subject ).to receive( :sorted_hosts ).and_return( [hosts[0]] )
       version = version_win = '3.1'
       path = "/path/to/upgradepkg"

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -50,7 +50,7 @@ describe ClassMixedWithDSLInstallUtils do
                                                 :working_dir => '/tmp' } ) }
   let(:unixhost)      { make_host( 'unixhost', { :platform => 'linux',
                                                  :pe_ver => '3.0',
-                                                :type => 'pe',
+                                                 :type => 'pe',
                                                  :working_dir => '/tmp',
                                                  :dist => 'puppet-enterprise-3.1.0-rc0-230-g36c9e5c-debian-7-i386' } ) }
   let(:eoshost)       { make_host( 'eoshost', { :platform => 'eos',
@@ -192,6 +192,7 @@ describe ClassMixedWithDSLInstallUtils do
     it 'generates a unix PE install command for a unix host' do
       the_host = unixhost.dup
       the_host['pe_installer'] = 'puppet-enterprise-installer'
+      the_host['pe_installer_conf_setting'] = '-a /tmp/answers'
       expect( subject.installer_cmd( the_host, {} ) ).to be === "cd /tmp/puppet-enterprise-3.1.0-rc0-230-g36c9e5c-debian-7-i386 && ./puppet-enterprise-installer -a /tmp/answers"
     end
 
@@ -229,6 +230,7 @@ describe ClassMixedWithDSLInstallUtils do
     it 'generates a unix PE install command in verbose for a unix host when pe_debug is enabled' do
       the_host = unixhost.dup
       the_host['pe_installer'] = 'puppet-enterprise-installer'
+      the_host['pe_installer_conf_setting'] = '-a /tmp/answers'
       the_host[:pe_debug] = true
       expect( subject.installer_cmd( the_host, {} ) ).to be === "cd /tmp/puppet-enterprise-3.1.0-rc0-230-g36c9e5c-debian-7-i386 && ./puppet-enterprise-installer -D -a /tmp/answers"
     end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -83,6 +83,7 @@ module HostHelpers
     host = make_opts.merge(host_hash)
 
     allow(host).to receive( :name ).and_return( name )
+    allow(host).to receive( :hostname ).and_return( "#{name}.test" )
     allow(host).to receive( :to_s ).and_return( name )
     allow(host).to receive( :exec ).and_return( generate_result( name, host_hash ) )
     host


### PR DESCRIPTION
This PR requires puppetlabs/beaker-answers#16.

This PR makes several changes to beaker-pe to allow it to handle either legacy or meep installers, and to work with a beaker-answers which has been modified to do the same.  It includes some transitional code to handle current builds which have both legacy and meep installers in the tarball.  This is toggled by the INSTALLER_TYPE environment variable.

This logic is isolated to the use_meep?() function.

There is some cleanup in the specs where these changes were colliding with some of the existing mocks.

~~TODO: need to fix up the Higgs install calls as well.~~ Done