### PR TITLE
(maint) Remove leftover comments

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -649,7 +649,7 @@ module Beaker
         #                      This is ignored if a pe_upgrade_ver and pe_upgrade_dir are specified
         #                      in the host configuration file.
         # @example
-        #  pre_host_for_upgrade(master, {}, "http://neptune.puppetlabs.lan/3.0/ci-ready/")
+        #  prep_host_for_upgrade(master, {}, "http://neptune.puppetlabs.lan/3.0/ci-ready/")
         def prep_host_for_upgrade(host, opts={}, path='')
           host['pe_dir'] = host['pe_upgrade_dir'] || path
           if host['platform'] =~ /windows/

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -12,6 +12,8 @@ class ClassMixedWithDSLInstallUtils
 
   attr_accessor :hosts
 
+  # Because some the methods now actually call out to the `step` method, we need to
+  # mock out `metadata` that is initialized in a test case.
   def metadata
     @metadata ||= {}
   end
@@ -444,9 +446,6 @@ describe ClassMixedWithDSLInstallUtils do
       #run rake task on dashboard
 
       expect( subject ).to receive( :on ).with( hosts[0], /\/opt\/puppet\/bin\/rake -sf \/opt\/puppet\/share\/puppet-dashboard\/Rakefile .* RAILS_ENV=production/ ).once
-      #wait for all hosts to appear in the dashboard
-      #run puppet agent now that installation is complete
-      #expect( subject ).to receive( :on ).with( hosts, /puppet agent/, :acceptable_exit_codes => [0,2] ).once
 
       hosts.each do |host|
         allow( host ).to receive( :tmpdir )


### PR DESCRIPTION
This removes some straggling comments and adds a comment to the new
metadata object in the `ClassMixedWithDSLInstallUtils` class.