### PR TITLE
(PE-14554) Switch default to meep

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -519,7 +519,7 @@ module Beaker
         #
         # And then to just >= 2016.2.0 for cutover.
         def use_meep?(version)
-          !version_is_less(version, MEEP_CUTOVER_VERSION) && ENV['INSTALLER_TYPE'] == 'meep'
+          !version_is_less(version, MEEP_CUTOVER_VERSION) && ENV['INSTALLER_TYPE'] != 'legacy'
         end
 
         # Set installer options on the passed *host* according to current

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -373,6 +373,13 @@ describe ClassMixedWithDSLInstallUtils do
         it 'sets legacy settings' do
           expect(slice_installer_options(host)).to eq(legacy_settings)
         end
+
+        it 'test use_meep?' do
+          expect(subject.use_meep?('3.8.5')).to eq(false)
+          expect(subject.use_meep?('2016.1.2')).to eq(false)
+          expect(subject.use_meep?('2016.2.0')).to eq(false)
+          expect(subject.use_meep?('2016.2.0-rc1-gabcdef')).to eq(false)
+        end
       end
 
       context 'and ENV["INSTALLER_TYPE"]=="meep"' do
@@ -380,6 +387,23 @@ describe ClassMixedWithDSLInstallUtils do
 
         it 'sets meep settings' do
           expect(slice_installer_options(host)).to eq(meep_settings)
+        end
+      end
+
+      context 'and ENV["INSTALLER_TYPE"] is not set' do
+        before(:each) do
+          ENV.delete('INSTALLER_TYPE')
+        end
+
+        it 'sets meep settings' do
+          expect(slice_installer_options(host)).to eq(meep_settings)
+        end
+
+        it 'test use_meep?' do
+          expect(subject.use_meep?('3.8.5')).to eq(false)
+          expect(subject.use_meep?('2016.1.2')).to eq(false)
+          expect(subject.use_meep?('2016.2.0')).to eq(true)
+          expect(subject.use_meep?('2016.2.0-rc1-gabcdef')).to eq(true)
         end
       end
     end


### PR DESCRIPTION
If INSTALLER_TYPE is not set, beaker-pe will now default to a meep
install.  You must set INSTALLER_TYPE to 'legacy' to get a legacy
install out of Beaker with this patch.