### PR TITLE
(PE-15351) Use -y option for 2016.2.1+ installs

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -109,7 +109,19 @@ module Beaker
             host.install_from_file("puppet-enterprise-#{version}-#{host['platform']}.swix")
           else
             pe_debug = host[:pe_debug] || opts[:pe_debug]  ? ' -D' : ''
-            "cd #{host['working_dir']}/#{host['dist']} && ./#{host['pe_installer']}#{pe_debug} #{host['pe_installer_conf_setting']}"
+            pe_cmd = "cd #{host['working_dir']}/#{host['dist']} && ./#{host['pe_installer']}#{pe_debug}"
+            if ! version_is_less(host['pe_ver'], '2016.2.1') && !(opts[:type] == :upgrade && version_is_less(host['pe_upgrade_ver'], '2016.2.1') )
+              # -f option forces non-interactive mode
+              pe_cmd += " -f"
+            end
+
+            # If there are no answer overrides, and we are doing an upgrade from 2016.2.0,
+            # we can assume there will be a valid pe.conf in /etc that we can re-use.
+            if opts[:answers].nil? && opts[:custom_answers].nil? && opts[:type] == :upgrade && !version_is_less(host['pe_ver'], '2016.2.0')
+              "#{pe_cmd}"
+            else
+              "#{pe_cmd} #{host['pe_installer_conf_setting']}"
+            end
           end
         end
 

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -110,14 +110,14 @@ module Beaker
           else
             pe_debug = host[:pe_debug] || opts[:pe_debug]  ? ' -D' : ''
             pe_cmd = "cd #{host['working_dir']}/#{host['dist']} && ./#{host['pe_installer']}#{pe_debug}"
-            if ! version_is_less(host['pe_ver'], '2016.2.1') && !(opts[:type] == :upgrade && version_is_less(host['pe_upgrade_ver'], '2016.2.1') )
+            if ! version_is_less(host['pe_ver'], '2016.2.1')
               # -f option forces non-interactive mode
               pe_cmd += " -f"
             end
 
             # If there are no answer overrides, and we are doing an upgrade from 2016.2.0,
             # we can assume there will be a valid pe.conf in /etc that we can re-use.
-            if opts[:answers].nil? && opts[:custom_answers].nil? && opts[:type] == :upgrade && !version_is_less(host['pe_ver'], '2016.2.0')
+            if opts[:answers].nil? && opts[:custom_answers].nil? && opts[:type] == :upgrade && !version_is_less(opts[:HOSTS][host.name][:pe_ver], '2016.2.0')
               "#{pe_cmd}"
             else
               "#{pe_cmd} #{host['pe_installer_conf_setting']}"

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -111,8 +111,8 @@ module Beaker
             pe_debug = host[:pe_debug] || opts[:pe_debug]  ? ' -D' : ''
             pe_cmd = "cd #{host['working_dir']}/#{host['dist']} && ./#{host['pe_installer']}#{pe_debug}"
             if ! version_is_less(host['pe_ver'], '2016.2.1')
-              # -f option forces non-interactive mode
-              pe_cmd += " -f"
+              # -y option sets "assume yes" mode where yes or whatever default will be assumed
+              pe_cmd += " -y"
             end
 
             # If there are no answer overrides, and we are doing an upgrade from 2016.2.0,


### PR DESCRIPTION
Prior to this commit there was not an option for signalling a
non-interactive install to the installer.
This commit adds the new `-f` option added in
https://github.com/puppetlabs/pe-installer-shim/pull/31 to the
command line options for installation/upgrade.

Additionally, this commit will remove the `-c` parameter being
passed on upgrades from a 2016.2.0+ install, because the installer
should be able to pick up on the existing pe.conf file.