### PR TITLE
(BKR-872) allow host's pe_ver to have precedence over the global pe_ver

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -575,7 +575,7 @@ module Beaker
         def generate_installer_conf_file_for(host, hosts, opts)
           beaker_answers_opts = setup_beaker_answers_opts(host, opts)
           answers = BeakerAnswers::Answers.create(
-            opts[:pe_ver] || host['pe_ver'], hosts, beaker_answers_opts
+            host['pe_ver'] || opts[:pe_ver], hosts, beaker_answers_opts
           )
           configuration = answers.installer_configuration_string(host)
 


### PR DESCRIPTION
This commit introduces a change where we use the global pe_ver if it is
not defined at the host level. Prior to this commit, upgrades would end
up using the global pe_ver for Answer file generation instead of the
host pe_ver. This would work if the global pe_ver was not defined, but
would end up generating the wrong Answer type if the global pe_ver was
defined.
