### PR TITLE
(MAINT) Fix install/pe_utils spec test

### DIFF
--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -866,6 +866,10 @@ describe ClassMixedWithDSLInstallUtils do
                          }, 2)
       hosts[0][:roles] = ['master', 'database', 'dashboard']
       hosts[1][:platform] = Beaker::Platform.new('el-6-x86_64')
+      opts[:HOSTS] = {}
+      hosts.each do |host|
+        opts[:HOSTS][host.name] = host
+      end
 
       allow( subject ).to receive( :hosts ).and_return( hosts )
       allow( subject ).to receive( :options ).and_return(Beaker::Options::Presets.new.presets)


### PR DESCRIPTION
Changes introduced at commit 33cdfef caused the install/pe_utils
spec test to fail. This commit updates the spec test to introduce
the `opts[:HOSTS]` data that the implementation code expects to have
available.