### PR TITLE
(BKR-922) fixed options reference for beaker-rspec

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -715,7 +715,7 @@ module Beaker
         def check_console_status_endpoint(host)
           return true if version_is_less(host['pe_ver'], '2015.2.0')
 
-          attempts_limit = @options[:pe_console_status_attempts] || 9
+          attempts_limit = options[:pe_console_status_attempts] || 9
           step 'Check Console Status Endpoint' do
             match = repeat_fibonacci_style_for(attempts_limit) do
               output = on(host, "curl -s -k https://localhost:4433/status/v1/services --cert /etc/puppetlabs/puppet/ssl/certs/#{host}.pem --key /etc/puppetlabs/puppet/ssl/private_keys/#{host}.pem --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem", :accept_all_exit_codes => true)

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1215,7 +1215,7 @@ describe ClassMixedWithDSLInstallUtils do
     it 'allows the number of attempts to be configured via the global options' do
       attempts = 37819
       options = {:pe_console_status_attempts => attempts}
-      subject.instance_variable_set(:@options, options)
+      allow(subject).to receive(:options).and_return(options)
       allow(subject).to receive(:version_is_less).and_return(false)
       allow(subject).to receive(:fail_test)
 
@@ -1224,7 +1224,7 @@ describe ClassMixedWithDSLInstallUtils do
     end
 
     it 'yields false to repeat_fibonacci_style_for when conditions are not true' do
-      subject.instance_variable_set(:@options, {})
+      allow(subject).to receive(:options).and_return({})
       allow(subject).to receive(:version_is_less).and_return(false)
       allow(subject).to receive(:sleep)
 
@@ -1240,7 +1240,7 @@ describe ClassMixedWithDSLInstallUtils do
     end
 
     it 'yields false to repeat_fibonacci_style_for when JSON::ParserError occurs' do
-      subject.instance_variable_set(:@options, {})
+      allow(subject).to receive(:options).and_return({})
       allow(subject).to receive(:version_is_less).and_return(false)
       allow(subject).to receive(:sleep)
 
@@ -1253,7 +1253,7 @@ describe ClassMixedWithDSLInstallUtils do
     end
 
     it 'calls fail_test when no checks pass' do
-      subject.instance_variable_set(:@options, {})
+      allow(subject).to receive(:options).and_return({})
       allow(subject).to receive(:version_is_less).and_return(false)
 
       allow(subject).to receive(:repeat_fibonacci_style_for).and_return(false)


### PR DESCRIPTION
In BKR-908, code was added to make console timeout checking
configurable. This code relied on `@options` to get the
value from the global option. This works in beaker but not
in beaker-rspec, because `@options` is a TestCase instance
variable. The accessor `options` works in both, because it
is a TestCase accessor in beaker, and a similar method has
been added in beaker-rspec's [shim](https://github.com/puppetlabs/beaker-rspec/blob/master/lib/beaker-rspec/beaker_shim.rb#L26-L28).