### PR TITLE
(BKR-941) beaker-pe 1.0 changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :acceptance_testing do
 end
 
 if ENV['GEM_SOURCE'] =~ /rubygems\.delivery\.puppetlabs\.net/
-  gem "scooter", *location_for(ENV['SCOOTER_VERSION'] || '~> 2.0')
+  gem "scooter", *location_for(ENV['SCOOTER_VERSION'] || '~> 3.0')
 end
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ end
 # We don't put beaker in as a test dependency because we
 # don't want to create a transitive dependency
 group :acceptance_testing do
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 2.0')
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.0')
 end
 
 if ENV['GEM_SOURCE'] =~ /rubygems\.delivery\.puppetlabs\.net/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@ The PE Beaker library contains all PE-specific
 
 that help someone acceptance test PE easier with Beaker.
 
+# Upgrading from 0.y to 1.y?
+
+If you've used beaker-pe previously (during the 0.y versions), you'll
+have to change the way that you include beaker-pe for 1.y versions &
+beyond.
+
+Before, you could just include beaker itself and you'd get beaker-pe
+because beaker required beaker-pe. With beaker 3.0, this dependency has
+been taken out of beaker. Now to use beaker-pe, you'll have to do two
+things:
+
+1. add a beaker-pe requirement as a sibling to your current beaker gem
+  requirement
+2. put a `require 'beaker-pe'` statement in your tests/code that need
+  beaker-pe-specific functionality
+
 # Spec Testing
 
 Spec tests all live under the `spec` folder.  These are the default rake task, &

--- a/beaker-pe.gemspec
+++ b/beaker-pe.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
+  s.add_runtime_dependency 'beaker-answers', '~> 0.0'
 
 end
 

--- a/lib/beaker-pe.rb
+++ b/lib/beaker-pe.rb
@@ -19,13 +19,11 @@ module Beaker
 end
 
 
-# This is commented out because Beaker is going to include this
-# library itself until version 3.0.
-# # Boilerplate DSL inclusion mechanism:
-# # First we register our module with the Beaker DSL
-# Beaker::DSL.register( Beaker::DSL::PE )
-# # Then we have to re-include our amended DSL in the TestCase,
-# # because in general, the DSL is included in TestCase far
-# # before test files are executed, so our amendments wouldn't
-# # come through otherwise
-# include Beaker::DSL
+# Boilerplate DSL inclusion mechanism:
+# First we register our module with the Beaker DSL
+Beaker::DSL.register( Beaker::DSL::PE )
+# Then we have to re-include our amended DSL in the TestCase,
+# because in general, the DSL is included in TestCase far
+# before test files are executed, so our amendments wouldn't
+# come through otherwise
+include Beaker::DSL

--- a/spec/beaker_test_helpers.rb
+++ b/spec/beaker_test_helpers.rb
@@ -1,0 +1,17 @@
+# These are specifically to mock Beaker methods necessary for testing
+# that will be available during runtime because this is never run separate
+# from Beaker itself.
+#
+# Including Beaker as a dependency would not work as a solution to this issue,
+# since that would make a cycle in the dependency graph, at least until
+# Beaker 3.0 happens and this is no longer a dependency of Beaker's.
+module BeakerTestHelpers
+  include Beaker::DSL
+end
+
+module Beaker
+  module DSL
+    def self.register( helper )
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'simplecov'
+require 'beaker_test_helpers'
 require 'beaker-pe'
 require 'helpers'
 


### PR DESCRIPTION
These are the changes required to update beaker-pe to
its first major version. These changes are done to use
the beaker 3.0 DSL library inclusion mechanism, pulling
the current beaker-pe requirement out of beaker itself