### PR TITLE
(BKR-945) Add acceptance tests to beaker-pe

### DIFF
--- a/acceptance/lib/test_helpers.rb
+++ b/acceptance/lib/test_helpers.rb
@@ -1,0 +1,1 @@
+require 'beaker-pe'

--- a/acceptance/pre_suite/install.rb
+++ b/acceptance/pre_suite/install.rb
@@ -1,0 +1,1 @@
+install_pe

--- a/acceptance/tests/install_smoke_test.rb
+++ b/acceptance/tests/install_smoke_test.rb
@@ -1,0 +1,21 @@
+test_name "puppet install smoketest"
+
+step 'puppet install smoketest: verify \'facter --help\' can be successfully called on all hosts'
+hosts.each do |host|
+  on host, facter('--help')
+end
+
+step 'puppet install smoketest: verify \'hiera --help\' can be successfully called on all hosts'
+hosts.each do |host|
+  on host, hiera('--help')
+end
+
+step 'puppet install smoketest: verify \'puppet help\' can be successfully called on all hosts'
+hosts.each do |host|
+  on host, puppet('help')
+end
+
+step "puppet install smoketest: can get a configprint of the puppet server setting on all hosts"
+hosts.each do |host|
+  assert(!host.puppet['server'].empty?, "can get a configprint of the puppet server setting")
+end


### PR DESCRIPTION
Previous to this commit, we relied on tests that existed within the
beaker repo to test functionality that actually resided within
beaker-pe. This change adds those tests to beaker-pe, so they can be
removed beaker itself.