### PR TITLE
(PE-17658) change beaker-pe to grab the right gpg key

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -554,7 +554,7 @@ module Beaker
               host_ver = host['pe_ver'] || opts['pe_ver']
 
               if version_is_less(host_ver, '3.8.5') || (!version_is_less(host_ver, '2015.2.0') && version_is_less(host_ver, '2016.1.2'))
-                on(host, 'curl http://apt.puppetlabs.com/pubkey.gpg | apt-key add -')
+                on(host, 'curl http://apt.puppetlabs.com/DEB-GPG-KEY-puppetlabs | apt-key add -')
               end
             end
           end


### PR DESCRIPTION
Prior to this change, beaker-pe was downloading
an expired key: pubkey.gpg, which caused packages
to fail authentication on debian platforms (ubuntu).

This commit updates the key we're getting to
DEB-GPG-KEY-puppetlabs which is still valid.