### PR TITLE
PE-17359 Fix windows frictionless upgrades

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -425,8 +425,8 @@ module Beaker
           end
 
           install_hosts.each do |host|
-            #windows agents from 4.0 -> 2016.1.2 were only installable via aio method
-            is_windows_msi_and_aio = (host['platform'] =~ /windows/ && (version_is_less(host['pe_ver'], '2016.3.0') && !version_is_less(host['pe_ver'], '3.99') && !(host['roles'].include?('frictionless'))))
+            #windows agents from 4.0 -> 2016.1.2 were only installable via the aio method
+            is_windows_msi_and_aio = (host['platform'] =~ /windows/ && (version_is_less(host['pe_ver'], '2016.3.0') && !version_is_less(host['pe_ver'], '3.99')))
 
             if agent_only_check_needed && hosts_agent_only.include?(host) || is_windows_msi_and_aio
               host['type'] = 'aio'


### PR DESCRIPTION
There was an error with my previous PR. PE 2016.2.1 to PE 2016.4.0
were failing because the PE 2016.2.1 install of the windows agent
would attempt to install via frictionless, and not with the old msi
method.
This PR fixes this.