### PR TITLE
(BKR-953) Stop including the dsl at the top level

### DIFF
--- a/lib/beaker-pe.rb
+++ b/lib/beaker-pe.rb
@@ -22,8 +22,13 @@ end
 # Boilerplate DSL inclusion mechanism:
 # First we register our module with the Beaker DSL
 Beaker::DSL.register( Beaker::DSL::PE )
-# Then we have to re-include our amended DSL in the TestCase,
-# because in general, the DSL is included in TestCase far
-# before test files are executed, so our amendments wouldn't
-# come through otherwise
-include Beaker::DSL
+
+# Second,We need to reload the DSL, but before we had reloaded
+# it in the global namespace, which result in errors colliding
+# with other gems rightfully not expecting beaker's dsl to
+# be available at the global level.
+module Beaker
+  class TestCase
+    include Beaker::DSL
+  end
+end


### PR DESCRIPTION
To reload the beaker dsl after adding modules to it, beaker-pe had just
included the module into the top level namespace. This resulted in
errors loading in other libraries not expecting the dsl to be loaded at
the top level. This commit changes that inclusion mechanism to be safe
from namespace collisions.