### PR TITLE
(PE-17825) Update do_higgs_install method with new installation log

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -899,7 +899,11 @@ module Beaker
 
           #wait for output to host['higgs_file']
           #we're all done when we find this line in the PE installation log
-          higgs_re = /o\s+to\s+https:\/\/.*\s+in\s+your\s+browser\s+to\s+continue\s+installation/m
+          if version_is_less(options[:pe_ver] || host['pe_ver'], '2016.3')
+            higgs_re = /Please\s+go\s+to\s+https:\/\/.*\s+in\s+your\s+browser\s+to\s+continue\s+installation/m
+          else
+            higgs_re = /o\s+to\s+https:\/\/.*\s+in\s+your\s+browser\s+to\s+continue\s+installation/m
+          end
           res = Result.new(host, 'tmp cmd')
           tries = 10
           attempts = 0

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -899,7 +899,7 @@ module Beaker
 
           #wait for output to host['higgs_file']
           #we're all done when we find this line in the PE installation log
-          higgs_re = /Please\s+go\s+to\s+https:\/\/.*\s+in\s+your\s+browser\s+to\s+continue\s+installation/m
+          higgs_re = /o\s+to\s+https:\/\/.*\s+in\s+your\s+browser\s+to\s+continue\s+installation/m
           res = Result.new(host, 'tmp cmd')
           tries = 10
           attempts = 0


### PR DESCRIPTION
Prior to this PR, the PE the do_higgs_install method waits for the below PE installation log:
"Please go to https://higgs_installer_web_server:3000 in your browser to continue installation"

However, newer PE, for example in Davis builds, that line of log has changed to be:
"#Go to  https://higgs_installer_web_server:3000 in your browser to continue installation"

This PR is a simple fix for this by only searching for the substring:
"o to  https://higgs_installer_web_server:3000 in your browser to continue installation"