### PR TITLE
(PE-17658) Update gpg key location

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -554,7 +554,7 @@ module Beaker
               host_ver = host['pe_ver'] || opts['pe_ver']
 
               if version_is_less(host_ver, '3.8.5') || (!version_is_less(host_ver, '2015.2.0') && version_is_less(host_ver, '2016.1.2'))
-                on(host, 'curl http://apt.puppetlabs.com/pubkey.gpg | apt-key add -')
+                on(host, 'curl http://apt.puppetlabs.com/DEB-GPG-KEY-puppetlabs | apt-key add -')
               end
             end
           end

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -445,7 +445,7 @@ describe ClassMixedWithDSLInstallUtils do
   end
 
   describe 'add_extended_gpg_key_to_hosts' do
-    let(:on_cmd) { 'curl http://apt.puppetlabs.com/pubkey.gpg | apt-key add -' }
+    let(:on_cmd) { 'curl http://apt.puppetlabs.com/DEB-GPG-KEY-puppetlabs | apt-key add -' }
     let(:deb_host) do
       host = hosts.first
       host['platform'] = 'debian'


### PR DESCRIPTION
Prior to this change, beaker-pe was downloading
an expired key: pubkey.gpg, which caused packages
to fail authentication on debian platforms (ubuntu).

This commit updates the key we're getting to
DEB-GPG-KEY-puppetlabs which is still valid.