### PR TITLE
(BKR-967) Add :disable_analytics option

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1,9 +1,12 @@
 [ 'aio_defaults', 'pe_defaults', 'puppet_utils', 'windows_utils' ].each do |lib|
     require "beaker/dsl/install_utils/#{lib}"
 end
+require "beaker/host_prebuilt_steps"
 require "beaker-answers"
 require "timeout"
 require "json"
+require "beaker-pe/options/presets"
+
 module Beaker
   module DSL
     module InstallUtils
@@ -22,6 +25,7 @@ module Beaker
         include PEDefaults
         include PuppetUtils
         include WindowsUtils
+        include HostPrebuiltSteps
 
         # Version of PE when we switched from legacy installer to MEEP.
         MEEP_CUTOVER_VERSION = '2016.2.0'
@@ -705,6 +709,12 @@ module Beaker
           install_pe_on(hosts, options)
         end
 
+        def disable_analytics(hosts)
+          logger.info("Disabling analytics on dashboard host(s)")
+          set_etc_hosts(hosts, "127.0.0.1\tgoogle-analytics.com\n")
+          set_etc_hosts(hosts, "127.0.0.1\twww.google-analytics.com\n")
+        end
+
         def check_puppetdb_status_endpoint(host)
           if version_is_less(host['pe_ver'], '2016.1.0')
             return true
@@ -774,6 +784,8 @@ module Beaker
         #   options, refer to {#do_install} documentation
         #
         def install_pe_on(install_hosts, opts)
+          opts = pe_presets.merge(opts)
+
           confine_block(:to, {}, install_hosts) do
             sorted_hosts.each do |host|
               #process the version files if necessary
@@ -791,6 +803,11 @@ module Beaker
                 host['pe_ver'] ||= Beaker::Options::PEVersionScraper.load_pe_version(host[:pe_dir] || opts[:pe_dir], opts[:pe_version_file])
               end
             end
+
+            if opts[:disable_analytics] then
+              disable_analytics(dashboard)
+            end
+
             do_install sorted_hosts, opts
           end
         end

--- a/lib/beaker-pe/options/presets.rb
+++ b/lib/beaker-pe/options/presets.rb
@@ -1,0 +1,9 @@
+# Generates an OptionsHash of preset values for Beaker options relating to PE
+#
+# @return [OptionsHash] The supported arguments in an OptionsHash
+def pe_presets
+  h = Beaker::Options::OptionsHash.new
+  h.merge({
+    :disable_analytics => true,
+  })
+end

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'beaker'
+require 'beaker-pe/options/presets'
 
 class ClassMixedWithDSLInstallUtils
   include Beaker::DSL::InstallUtils
@@ -283,6 +284,7 @@ describe ClassMixedWithDSLInstallUtils do
       context 'the do_higgs_install' do
         it 'submits the correct installer cmd to invoke Higgs' do
           prep_host(host)
+          allow( subject ).to receive( :options ).and_return( {} )
           subject.do_higgs_install(host, opts)
         end
       end
@@ -305,6 +307,7 @@ describe ClassMixedWithDSLInstallUtils do
       context 'the do_higgs_install' do
         it 'submits the correct installer cmd to invoke Higgs' do
           prep_host(host)
+          allow( subject ).to receive( :options ).and_return( {} )
           subject.do_higgs_install(host, opts)
         end
       end
@@ -889,6 +892,7 @@ describe ClassMixedWithDSLInstallUtils do
       end
 
       allow( subject ).to receive( :hosts ).and_return( hosts )
+      allow( subject ).to receive( :options ).and_return( {} )
       #create answers file per-host, except windows
       allow( subject ).to receive( :create_remote_file ).with( hosts[0], /answers/, /q/ )
       #run installer on all hosts
@@ -944,6 +948,7 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :sleep ).and_return( true )
 
       allow( subject ).to receive( :hosts ).and_return( hosts )
+      allow( subject ).to receive( :options ).and_return( {} )
 
       #run higgs installer command
       expect( subject ).to receive( :on ).with( hosts[0],
@@ -959,6 +964,7 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :sleep ).and_return( true )
 
       allow( subject ).to receive( :hosts ).and_return( hosts )
+      allow( subject ).to receive( :options ).and_return( {} )
 
       #run higgs installer command
       expect( subject ).to receive( :on ).with( hosts[0],
@@ -977,7 +983,35 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :options ).and_return( {} )
       allow( subject ).to receive( :hosts ).and_return( hosts_sorted )
       allow( subject ).to receive( :do_install ).and_return( true )
-      expect( subject ).to receive( :do_install ).with( hosts, {} )
+      allow( subject ).to receive( :set_etc_hosts )
+      expect( subject ).to receive( :do_install ).with( hosts, pe_presets )
+      subject.install_pe
+    end
+
+    it 'blocks analytics by default' do
+      allow( subject ).to receive( :options ).and_return( {} )
+      allow( subject ).to receive( :hosts ).and_return( hosts_sorted )
+      allow( subject ).to receive( :do_install ).and_return( true )
+      allow( subject ).to receive( :set_etc_hosts )
+      expect( subject ).to receive( :do_install ).with( hosts, pe_presets )
+      subject.install_pe
+    end
+
+    it 'blocks analytics when disable_analytics is true' do
+      allow( subject ).to receive( :options ).and_return( {:disable_analytics => true} )
+      allow( subject ).to receive( :hosts ).and_return( hosts_sorted )
+      allow( subject ).to receive( :do_install ).and_return( true )
+      allow( subject ).to receive( :set_etc_hosts )
+      expect( subject ).to receive( :do_install ).with( hosts, {:disable_analytics => true} )
+      subject.install_pe
+    end
+
+    it 'does not block analytics when disable_analytics is false' do
+      allow( subject ).to receive( :options ).and_return( {:disable_analytics => false} )
+      allow( subject ).to receive( :hosts ).and_return( hosts_sorted )
+      allow( subject ).to receive( :do_install ).and_return( true )
+      expect( subject ).to_not receive( :set_etc_hosts )
+      expect( subject ).to receive( :do_install ).with( hosts, {:disable_analytics => false} )
       subject.install_pe
     end
 
@@ -989,7 +1023,8 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :hosts ).and_return( hosts_sorted )
       allow( subject ).to receive( :options ).and_return( {} )
       allow( subject ).to receive( :do_install ).and_return( true )
-      expect( subject ).to receive( :do_install ).with( hosts, {} )
+      allow( subject ).to receive( :set_etc_hosts )
+      expect( subject ).to receive( :do_install ).with( hosts, pe_presets )
       subject.install_pe
       hosts.each do |h|
         expect( h['pe_ver'] ).to be === '2.8'
@@ -998,8 +1033,10 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'can act upon a single host' do
       allow( subject ).to receive( :hosts ).and_return( hosts )
+      allow( subject ).to receive( :options ).and_return( {} )
       allow( subject ).to receive( :sorted_hosts ).and_return( [hosts[0]] )
-      expect( subject ).to receive( :do_install ).with( [hosts[0]], {} )
+      allow( subject ).to receive( :set_etc_hosts )
+      expect( subject ).to receive( :do_install ).with( [hosts[0]], pe_presets )
       subject.install_pe_on(hosts[0], {})
     end
   end


### PR DESCRIPTION
Allow :disable_analytics to be set in beaker options, allowing us to block
traffic to Google Analytics.

Help wanted:
- Is this the right way to merge PE specific options with beaker options?
- Should the pe_presets be inside a module instead of raw included code?

TODO:
- Still need to add spec tests
