### PR TITLE
(PE-18516,PE-18170) Temporarily set pe.conf when upgrading to Flanders

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -123,9 +123,13 @@ module Beaker
               pe_cmd += " -y"
             end
 
+            # This is a temporary workaround for PE-18516, because MEEP does not yet create a 2.0
+            # pe.conf when recovering configuration in Flanders. This will be fixed in PE-18170.
+            if opts[:type] == :upgrade && !version_is_less(host['pe_upgrade_ver'], '2017.1.0')
+              "#{pe_cmd} #{host['pe_installer_conf_setting']}"
             # If there are no answer overrides, and we are doing an upgrade from 2016.2.0,
             # we can assume there will be a valid pe.conf in /etc that we can re-use.
-            if opts[:answers].nil? && opts[:custom_answers].nil? && opts[:type] == :upgrade && !version_is_less(opts[:HOSTS][host.name][:pe_ver], '2016.2.0')
+            elsif opts[:answers].nil? && opts[:custom_answers].nil? && opts[:type] == :upgrade && !version_is_less(opts[:HOSTS][host.name][:pe_ver], '2016.2.0')
               "#{pe_cmd}"
             else
               "#{pe_cmd} #{host['pe_installer_conf_setting']}"


### PR DESCRIPTION
At the moment, MEEP does not create a 2.0 pe.conf when recovering
configuration for an upgrade.  This is preventing all upgrade tests from
PE >= 2016.2 (when meep was introduced) to PE >= 2017.1 from completing
because meep ends up using a 1.0 pe.conf that has no node_roles. Without
the node_roles information, the node is not considered infrastructure,
and meep's enc returns no classes for it, so nothing happens in the
upgrade apply.

This is not currently a problem upgrading from < 2016.2 because
beaker-pe is providing the beaker-answers pe.conf in those cases.

To work around this, I've added a check, just if we are upgrading to a
Flanders version, which supplies the beaker-answers generated pe.conf.

This patch is just intended to get upgrades from earlier meep versions
working in CI. When we get to PE-18170 (also scheduled for Flanders)
we'll work on improving recover configuration to generate a 2.0 pe.conf,
with the goal being that beaker-answers should not need to provide
anything for pe.conf for Flanders upgrades unless some additional
parameters were added in the beaker configuration.