### PR TITLE
(BKR-831) Remove aio_agent_build as version source

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -578,11 +578,11 @@ module Beaker
         end
 
         # Gets the puppet-agent version, hopefully from the host or local options.
-        # Will fall back to reading the `aio_agent_build` property on the master
+        # Will fall back to reading the `aio_agent_version` property on the master
         # if neither of those two options are passed
         #
         # @note This method does have a side-effect: if it reads the
-        #   `aio_agent_build` property from master, it will store it in the local
+        #   `aio_agent_version` property from master, it will store it in the local
         #   options hash so that it won't have to do this more than once.
         #
         # @param [Beaker::Host] host Host to get puppet-agent for
@@ -600,9 +600,7 @@ module Beaker
           facts_result = on(master, 'puppet facts')
           raise ArgumentError, fail_message if facts_result.exit_code != 0
           facts_hash = JSON.parse(facts_result.stdout.chomp)
-          puppet_agent_version   = facts_hash['values']['aio_agent_build']
-          # released masters don't have _build fact, fallback to _version
-          puppet_agent_version ||= facts_hash['values']['aio_agent_version']
+          puppet_agent_version = facts_hash['values']['aio_agent_version']
           raise ArgumentError, fail_message if puppet_agent_version.nil?
           logger.warn("#{log_prefix} Read puppet-agent version #{puppet_agent_version} from master")
           # saving so that we don't have to query the master more than once

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1323,7 +1323,7 @@ describe ClassMixedWithDSLInstallUtils do
         json_hash    = mock_values[:json_hash]
         pa_version   = mock_values[:pa_version]
         pa_version ||= 'pa_version_' + rand(10 ** 5).to_s.rjust(5,'0') # 5 digit random number string
-        json_hash  ||= "{ \"values\": { \"aio_agent_build\": \"#{pa_version}\" }}"
+        json_hash  ||= "{ \"values\": { \"aio_agent_version\": \"#{pa_version}\" }}"
 
         allow( subject ).to receive( :master ).and_return( {} )
         result_mock = Object.new
@@ -1345,11 +1345,6 @@ describe ClassMixedWithDSLInstallUtils do
         expect( local_options_hash[:puppet_agent_version] ).to be === pa_version
       end
 
-      it 'falls back on aio_agent_version if _build is not available' do
-        pa_version = 'your_face_13587'
-        test_setup( :json_hash => "{ \"values\": { \"aio_agent_version\": \"#{pa_version}\" }}" )
-        expect( subject.get_puppet_agent_version( {} ) ).to be === pa_version
-      end
     end
 
     context 'failures' do


### PR DESCRIPTION
This commit removes the `aio_agent_build` fact as a data source for
the `get_puppet_agent_version`. If the version is not specified, then
then only the `aio_agent_version` value is used as a fail over.