### PR TITLE
(PE-19169) Add ability to pass in feature flags to install shim

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -119,6 +119,10 @@ module Beaker
               pe_cmd += " -y"
             end
 
+            if host[:installer_flags] || opts[:installer_flags]
+              pe_cmd += host[:installer_flags] || opts[:installer_flags]
+            end
+
             # This is a temporary workaround for PE-18516, because MEEP does not yet create a 2.0
             # pe.conf when recovering configuration in Flanders. This will be fixed in PE-18170.
             if opts[:type] == :upgrade && !version_is_less(host['pe_upgrade_ver'], '2017.1.0')


### PR DESCRIPTION
This PR adds in the ability to pass in additional flags into the
installer-shim for the purpose of testing feature flagged features.