### PR TITLE
(BKR-937) Add support for installing AIX 7 agent on 7.2

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -289,7 +289,14 @@ module Beaker
         # @param [Host] host The host to install pacakges for
         # @api private
         def deploy_frictionless_to_master(host)
-          klass = host['platform'].gsub(/-/, '_').gsub(/\./,'')
+          platform = host['platform']
+
+          # We don't have a separate AIX 7.2 build, so it is
+          # classified as 7.1 for pe_repo purposes
+          if platform == "aix-7.2-power"
+            platform = "aix-7.1-power"
+          end
+          klass = platform.gsub(/-/, '_').gsub(/\./,'')
           if host['platform'] =~ /windows/
             if host['template'] =~ /i386/
               klass = "pe_repo::platform::windows_i386"


### PR DESCRIPTION
To avoid unnecessarily expanding our build times, our initial support
for AIX 7.2 is through the existing 7.1 package. This will be replaced
with a single unified AIX build in the Agent 2.0 timeframe, but for now
we need to add a little bit of special-case logic to handle 7.2 with
existing packages.