### PR TITLE
(PE-19169) Add pe modules next flag

### DIFF
--- a/lib/beaker-pe/install/feature_flags.rb
+++ b/lib/beaker-pe/install/feature_flags.rb
@@ -1,0 +1,114 @@
+module Beaker::DSL::InstallUtils
+  # This helper class encapsulates querying feature flag settings from
+  # options[:answers] which can be used to drive Beaker's install behavior
+  # around new or experimental features, typically in the PE Modules.
+  #
+  # Also handles initializing feature flag settings from environment variables
+  # for CI. In this way, flags can be pulled in without needing to munge
+  # Beaker's config file which is often handled inside of a script in Jenkins.
+  #
+  # Flags are expected to be found in a +feature_flags+ hash in the
+  # options[:answers] under the key :feature_flags.  Beaker::OptionHash should
+  # ensure that all keys end up as symbols.  If you are programatically
+  # constructing the answers, you must take care to use merge() to add
+  # elements.
+  #
+  # @example The use of the pe-modules-next package is handled by:
+  #   :answers => {
+  #     :feature_flags => {
+  #       :pe_modules_next => true
+  #     }
+  #   }
+  #
+  # All flag keys are expected to be downcased with hyphens.
+  #
+  # Environment variables may be uppercased.
+  class FeatureFlags
+    FLAGS = %w{
+      pe_modules_next
+    }.freeze
+
+    attr_reader :options
+
+    def initialize(options)
+      @options = options
+    end
+
+    # Returns the boolean state of the flag as found in options[:answers],
+    # or if not found in the answers, then it checks for an environment variable.
+    #
+    # @param String flag key
+    # @return [Boolean,nil] boolean true or false unless not found at all, then nil.
+    def flag?(flag)
+      key = canonical_key(flag)
+      state = flags[key] if flags?
+      state = environment_flag?(key) if state.nil?
+
+      case state
+      when nil then nil
+      else state.to_s == 'true'
+      end
+    end
+
+    # Updates options[:answers][:feature_flags] with any environment variables
+    # found based on FLAGS, but if and only if they are not already present.
+    #
+    # (existing :answers take precedence)
+    def register_flags!
+      answers_with_registered_flags = answers
+      answers_with_registered_flags[:feature_flags] ||= StringifyHash.new
+      new_flags = answers_with_registered_flags[:feature_flags]
+
+      FLAGS.each do |flag|
+        key = canonical_key(flag)
+        value = flag?(key)
+        if !new_flags.include?(key) && !value.nil?
+          new_flags[key] = value
+        end
+      end
+
+      options.merge!(
+        :answers => answers_with_registered_flags
+      ) if !new_flags.empty?
+
+      options
+    end
+
+    private
+
+    # Does the +feature_flags+ hash exist?
+    def flags?
+      answers? && !answers[:feature_flags].nil?
+    end
+
+    def flags
+      answers[:feature_flags] || StringifyHash.new
+    end
+
+    # Does the +answers+ hash exist?
+    def answers?
+      !options[:answers].nil?
+    end
+
+    def answers
+      options[:answers] || StringifyHash.new
+    end
+
+    def canonical_key(key)
+      key.to_s.downcase.to_sym
+    end
+
+    def environmental_keys(key)
+      [key.to_s.upcase, key.to_s.downcase]
+    end
+
+    def environment_flag?(flag)
+      value = nil
+      environmental_keys(flag).each do |f|
+        value = ENV[f] if ENV.include?(f)
+        break if !value.nil?
+      end
+      value
+    end
+  end
+end

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -119,13 +119,9 @@ module Beaker
               pe_cmd += " -y"
             end
 
-            # This is a temporary workaround for PE-18516, because MEEP does not yet create a 2.0
-            # pe.conf when recovering configuration in Flanders. This will be fixed in PE-18170.
-            if opts[:type] == :upgrade && !version_is_less(host['pe_upgrade_ver'], '2017.1.0')
-              "#{pe_cmd} #{host['pe_installer_conf_setting']}"
             # If there are no answer overrides, and we are doing an upgrade from 2016.2.0,
             # we can assume there will be a valid pe.conf in /etc that we can re-use.
-            elsif opts[:answers].nil? && opts[:custom_answers].nil? && opts[:type] == :upgrade && !version_is_less(opts[:HOSTS][host.name][:pe_ver], '2016.2.0')
+            if opts[:answers].nil? && opts[:custom_answers].nil? && opts[:type] == :upgrade && !version_is_less(opts[:HOSTS][host.name][:pe_ver], '2016.2.0')
               "#{pe_cmd}"
             else
               "#{pe_cmd} #{host['pe_installer_conf_setting']}"

--- a/spec/beaker-pe/install/feature_flags_spec.rb
+++ b/spec/beaker-pe/install/feature_flags_spec.rb
@@ -1,0 +1,174 @@
+require 'spec_helper'
+
+describe Beaker::DSL::InstallUtils::FeatureFlags do
+  let(:options) do
+    opts= Beaker::Options::Presets.new
+    opts.presets.merge(opts.env_vars)
+  end
+  let(:flags) { Beaker::DSL::InstallUtils::FeatureFlags.new(options) }
+  let(:answers) do
+    {
+      'answers' => {
+         'feature_flags' => feature_flags
+      }
+    }
+  end
+  let(:feature_flags) { {} }
+  let(:feature_flags) do
+    {
+      'pe_modules_next' => flag
+    }
+  end
+  let(:environment_flag_key) { "PE_MODULES_NEXT" }
+  let(:environment_flag_value) {}
+
+  context 'neither answers nor env' do
+    it { expect(flags.send(:answers)).to eq(StringifyHash.new) }
+    it { expect(flags.send(:answers?)).to eq(false) }
+    it { expect(flags.send(:flags)).to eq(StringifyHash.new) }
+    it { expect(flags.send(:flags?)).to eq(false) }
+    it { expect(flags.flag?('foo')).to be_nil }
+    it { expect(flags.flag?(:pe_modules_next)).to be_nil }
+    it { expect(flags.flag?('pe_modules_next')).to be_nil }
+  end
+
+  context 'answers' do
+    let(:flag) {}
+
+    before(:each) do
+      options.merge!(answers)
+    end
+
+    it { expect(flags.flag?('pe_modules_next')).to be_nil }
+
+    context 'with flag' do
+      context 'true' do
+        let(:flag) { true }
+        it { expect(flags.flag?('pe_modules_next')).to eq(true) }
+        it { expect(flags.flag?(:pe_modules_next)).to eq(true) }
+      end
+
+      context 'true as a string' do
+        let(:flag) { 'true' }
+        it { expect(flags.flag?('pe_modules_next')).to eq(true) }
+        it { expect(flags.flag?(:pe_modules_next)).to eq(true) }
+      end
+
+      context 'false' do
+        let(:flag) { false }
+        it { expect(flags.flag?('pe_modules_next')).to eq(false) }
+        it { expect(flags.flag?(:pe_modules_next)).to eq(false) }
+      end
+
+      context 'false as a string' do
+        let(:flag) { 'false' }
+        it { expect(flags.flag?('pe_modules_next')).to eq(false) }
+        it { expect(flags.flag?(:pe_modules_next)).to eq(false) }
+      end
+    end
+  end
+
+  context 'env' do
+    before(:each) do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:include?).and_call_original
+      expect(ENV).to receive(:[]).with(environment_flag_key).and_return(environment_flag_value)
+      expect(ENV).to receive(:include?).with(environment_flag_key).and_return(true)
+    end
+
+    it { expect(flags.flag?(:pe_modules_next)).to eq(nil) }
+
+    context 'with flag' do
+      context 'true' do
+        let(:environment_flag_value) { 'true' }
+        it { expect(flags.flag?('pe_modules_next')).to eq(true) }
+        it { expect(flags.flag?(:pe_modules_next)).to eq(true) }
+      end
+
+      context 'false' do
+        let(:environment_flag_value) { 'false' }
+        it { expect(flags.flag?('pe_modules_next')).to eq(false) }
+        it { expect(flags.flag?(:pe_modules_next)).to eq(false) }
+      end
+    end
+  end
+
+  context 'answers and env' do
+    before(:each) do
+      options.merge!(answers)
+      allow(ENV).to receive(:include?).and_call_original
+      expect(ENV).to_not receive(:include?).with('pe_modules_next')
+      expect(ENV).to_not receive(:include?).with('PE_MODULES_NEXT')
+    end
+
+    context 'answers true and env false' do
+      let(:flag) { 'true' }
+
+      it { expect(flags.flag?(:pe_modules_next)).to eq(true) }
+    end
+
+    context 'answers false and env true' do
+      let(:flag) { 'false' }
+
+      it { expect(flags.flag?(:pe_modules_next)).to eq(false) }
+    end
+  end
+
+  context 'registering flags' do
+    it do
+      expect(flags.register_flags!).to eq(options)
+      expect(options[:answers]).to be_nil
+    end
+
+    context 'with env variables' do
+      before(:each) do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:include?).and_call_original
+        expect(ENV).to receive(:include?).with('pe_modules_next').and_return(true)
+      end
+
+      it 'picks up a true flag from environment' do
+        expect(ENV).to receive(:[]).with('pe_modules_next').and_return('true')
+
+        flags.register_flags!
+        expect(options[:answers]).to match(
+          :feature_flags => {
+            :pe_modules_next => true
+          }
+        )
+      end
+
+      it 'picks up a false flag from environment' do
+        expect(ENV).to receive(:[]).with('pe_modules_next').and_return('false')
+
+        flags.register_flags!
+        expect(options[:answers]).to match(
+          :feature_flags => {
+            :pe_modules_next => false
+          }
+        )
+      end
+    end
+
+    context 'with answers and env variables' do
+      let(:flag) { false }
+
+      before(:each) do
+        answers['answers'][:some_other_answer] = 'value'
+        options.merge!(answers)
+        allow(ENV).to receive(:include?).and_call_original
+        expect(ENV).to_not receive(:include?).with('pe_modules_next')
+      end
+
+      it do
+        flags.register_flags!
+        expect(options[:answers]).to match(
+          :some_other_answer => 'value',
+          :feature_flags => {
+            :pe_modules_next => false
+          },
+        )
+      end
+    end
+  end
+end

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -416,6 +416,28 @@ describe ClassMixedWithDSLInstallUtils do
     end
   end
 
+  describe 'register_feature_flags' do
+    it 'does nothing if no flag is set' do
+      expect(subject.register_feature_flags(opts)).to be_nil
+      expect(opts[:answers]).to be_nil
+    end
+
+    context 'with flag set' do
+      before(:each) do
+        allow(ENV).to receive(:[]).and_call_original
+        expect(ENV).to receive(:[]).with('PE_MODULES_NEXT').and_return('true')
+      end
+
+      it 'updates answers' do
+        expect(subject.register_feature_flags(opts)).to match({
+          'feature_flags' => {
+            'pe_modules_next' => true
+          }
+        })
+      end
+    end
+  end
+
   describe 'setup_beaker_answers_opts' do
     let(:opts) { {} }
     let(:host) { hosts.first }

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -438,6 +438,37 @@ describe ClassMixedWithDSLInstallUtils do
     end
   end
 
+  describe 'feature_flag?' do
+
+    context 'without :answers' do
+      it 'is false for pe_modules_next' do
+        expect(subject.feature_flag?('pe_modules_next', opts)).to eq(false)
+      end
+    end
+
+    context 'with :answers' do
+      before(:each) do
+        opts[:answers] = {}
+      end
+
+      it 'is false for pe_modules_next' do
+        expect(subject.feature_flag?('pe_modules_next', opts)).to eq(false)
+      end
+    end
+
+    context 'with answers set' do
+      before(:each) do
+        opts[:answers] ||= {}
+        opts[:answers]['feature_flags'] ||= {}
+        opts[:answers]['feature_flags']['pe_modules_next'] = true
+      end
+
+      it 'is true for pe_modules_next' do
+        expect(subject.feature_flag?('pe_modules_next', opts)).to eq(true)
+      end
+    end
+  end
+
   describe 'setup_beaker_answers_opts' do
     let(:opts) { {} }
     let(:host) { hosts.first }
@@ -465,6 +496,24 @@ describe ClassMixedWithDSLInstallUtils do
             :include_legacy_database_defaults => false,
           )
         )
+      end
+
+      context 'with pe-modules-next' do
+        before(:each) do
+          opts[:answers] ||= {}
+          opts[:answers]['feature_flags'] ||= {}
+          opts[:answers]['feature_flags']['pe_modules_next'] = true
+        end
+
+        it 'adds meep_schema_version' do
+          expect(subject.setup_beaker_answers_opts(host, opts)).to eq(
+            opts.merge(
+              :format => :hiera,
+              :include_legacy_database_defaults => false,
+              :meep_schema_version => '2.0',
+            )
+          )
+        end
       end
 
       context 'when upgrading' do


### PR DESCRIPTION
Register flag for pe-modules-next if present in ENV ￼…
Major PE modules development work is being done in a separate
pe-modules-next package. The installer shim decides which pe-modules
package to install based on a pe.conf flag. This patch allows Jenkins CI
to trigger this by picking up ENV['PE_MODULES_NEXT'] and ensure that the
flag is set in the opts[:answers] which will then be transferred to
pe.conf by beaker-answers, and then picked up by the installer shim
during installation.

---

Remove version specific upgrade hack ￼…
This had been added to allow upgrade testing in flanders with meep for
classification prior to our having completed an upgrade workflow in the
installer.

Now that meep is being worked on in the pe-modules-next package behind a
feature-flag, this gate is counter-productive, particularly for Flanders
upgrade testing because it masks the common case of upgrading without
specifying a pe.conf.