### PR TITLE
(BKR-806) Only add pe_repo classes once

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -340,11 +340,13 @@ module Beaker
               node_group['classes'] ||= {}
             end
 
-            # add the pe_repo platform class
-            node_group['classes'][klass] = {}
+            # add the pe_repo platform class if it's not already present
+            if ! node_group['classes'].include?(klass)
+              node_group['classes'][klass] = {}
 
-            _console_dispatcher.create_new_node_group_model(node_group)
-            on master, puppet("agent -t"), :acceptable_exit_codes => [0,2]
+              _console_dispatcher.create_new_node_group_model(node_group)
+              on master, puppet("agent -t"), :acceptable_exit_codes => [0,2]
+            end
           end
         end
 


### PR DESCRIPTION
Previously, if installing multiple agents with the same platform, the
work to add the appropriate pe_repo class to the master would be
performed once for each agent. Because that requires running `puppet
agent -t` on the master, it can add a significant amount of unnecessary
overhead to the install process when installing several agents.

We now check whether the class has already been included in the Beaker
Frictionless Agent group and skip running puppet on the master if it
has.

This could be further improved by adding all the appropriate classes at once,
or by skipping the step if the agents are the same platform as the master.
Because agents are installed one at a time, that's a less natural change to
make. For now, this will provide a tangible benefit for a small amount of
change.