### PR TITLE
(MAINT) remove wait_for_host_in_dashboard call

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -497,10 +497,6 @@ module Beaker
               end
             end
 
-            install_hosts.each do |host|
-              wait_for_host_in_dashboard(host)
-            end
-
             # only appropriate for pre-3.9 builds
             if version_is_less(master[:pe_ver], '3.99')
               if pre30master

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -811,7 +811,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :stop_agent_on ).and_return( true )
       allow( subject ).to receive( :sleep_until_puppetdb_started ).and_return( true )
       allow( subject ).to receive( :max_version ).with(anything, '3.8').and_return('3.0')
-      allow( subject ).to receive( :wait_for_host_in_dashboard ).and_return( true )
       allow( subject ).to receive( :puppet_agent ) do |arg|
         "puppet agent #{arg}"
       end
@@ -887,7 +886,6 @@ describe ClassMixedWithDSLInstallUtils do
       expect( subject ).to_not receive( :sign_certificate_for )
       expect( subject ).to receive( :stop_agent_on ).with( hosts[0] ).once
       expect( subject ).to_not receive( :sleep_until_puppetdb_started )
-      expect( subject ).to_not receive( :wait_for_host_in_dashboard )
       expect( subject ).to_not receive( :on ).with( hosts[0], /puppet agent -t/, :acceptable_exit_codes => [0,2] )
 
       hosts.each do |host|
@@ -916,7 +914,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :stop_agent_on ).and_return( true )
       allow( subject ).to receive( :sleep_until_puppetdb_started ).and_return( true )
       allow( subject ).to receive( :max_version ).with(anything, '3.8').and_return('4.0')
-      allow( subject ).to receive( :wait_for_host_in_dashboard ).and_return( true )
       allow( subject ).to receive( :puppet_agent ) do |arg|
         "puppet agent #{arg}"
       end
@@ -993,7 +990,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :stop_agent_on ).and_return( true )
       allow( subject ).to receive( :sleep_until_puppetdb_started ).and_return( true )
       allow( subject ).to receive( :max_version ).with(anything, '3.8').and_return('4.0')
-      allow( subject ).to receive( :wait_for_host_in_dashboard ).and_return( true )
       allow( subject ).to receive( :puppet_agent ) do |arg|
         "puppet agent #{arg}"
       end
@@ -1063,7 +1059,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :stop_agent_on ).and_return( true )
       allow( subject ).to receive( :sleep_until_puppetdb_started ).and_return( true )
       allow( subject ).to receive( :max_version ).with(anything, '3.8').and_return('4.0')
-      allow( subject ).to receive( :wait_for_host_in_dashboard ).and_return( true )
       allow( subject ).to receive( :puppet_agent ) do |arg|
         "puppet agent #{arg}"
       end


### PR DESCRIPTION
@jonathannewman submitted the original change request in https://github.com/puppetlabs/beaker/pull/1339.

@puppetlabs/integration do you think there are any versions we're still testing that would be affected by this?