### PR TITLE
(MAINT) add pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+Please delete any headings that don't apply to this Pull Request (PR).
+
+#### What's this PR do?
+#### Who would you like to review this PR?
+
+@puppetlabs/integration, @puppetlabs/beaker (repo owners)
+
+#### Should any of this be tested outside the normal PR CI cycle?
+#### Any background context you want to provide?
+#### Questions for reviewers?


### PR DESCRIPTION
adds a template that will make understanding
who to ping to get your PR reviewed clearer.

[skip ci]

- [pr template github help](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/)

@nicklewis would this help make who you should ping clearer for PRs going forward?

@puppetlabs/integration is this the right group of people to ping? Have any other feedback or questions on this?