### PR TITLE
(maint) Remove `wait_for_host_in_dashboard`

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -501,10 +501,6 @@ module Beaker
               end
             end
 
-            install_hosts.each do |host|
-              wait_for_host_in_dashboard(host)
-            end
-
             # only appropriate for pre-3.9 builds
             if version_is_less(master[:pe_ver], '3.99')
               if pre30master

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -659,7 +659,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :stop_agent_on ).and_return( true )
       allow( subject ).to receive( :sleep_until_puppetdb_started ).and_return( true )
       allow( subject ).to receive( :max_version ).with(anything, '3.8').and_return('3.0')
-      allow( subject ).to receive( :wait_for_host_in_dashboard ).and_return( true )
       allow( subject ).to receive( :puppet_agent ) do |arg|
         "puppet agent #{arg}"
       end
@@ -735,7 +734,6 @@ describe ClassMixedWithDSLInstallUtils do
       expect( subject ).to_not receive( :sign_certificate_for )
       expect( subject ).to receive( :stop_agent_on ).with( hosts[0] ).once
       expect( subject ).to_not receive( :sleep_until_puppetdb_started )
-      expect( subject ).to_not receive( :wait_for_host_in_dashboard )
       expect( subject ).to_not receive( :on ).with( hosts[0], /puppet agent -t/, :acceptable_exit_codes => [0,2] )
 
       hosts.each do |host|
@@ -764,7 +762,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :stop_agent_on ).and_return( true )
       allow( subject ).to receive( :sleep_until_puppetdb_started ).and_return( true )
       allow( subject ).to receive( :max_version ).with(anything, '3.8').and_return('4.0')
-      allow( subject ).to receive( :wait_for_host_in_dashboard ).and_return( true )
       allow( subject ).to receive( :puppet_agent ) do |arg|
         "puppet agent #{arg}"
       end
@@ -821,7 +818,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :stop_agent_on ).and_return( true )
       allow( subject ).to receive( :sleep_until_puppetdb_started ).and_return( true )
       allow( subject ).to receive( :max_version ).with(anything, '3.8').and_return('4.0')
-      allow( subject ).to receive( :wait_for_host_in_dashboard ).and_return( true )
       allow( subject ).to receive( :puppet_agent ) do |arg|
         "puppet agent #{arg}"
       end
@@ -880,7 +876,6 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :stop_agent_on ).and_return( true )
       allow( subject ).to receive( :sleep_until_puppetdb_started ).and_return( true )
       allow( subject ).to receive( :max_version ).with(anything, '3.8').and_return('4.0')
-      allow( subject ).to receive( :wait_for_host_in_dashboard ).and_return( true )
       allow( subject ).to receive( :puppet_agent ) do |arg|
         "puppet agent #{arg}"
       end


### PR DESCRIPTION
This appears to be a 3.x-era holdover that's no longer relevant, so
remove it from the `do_install` method in the PE install utils.

#### What's this PR do?
Remove the call to `wait_for_host_in_dashboard` in the `do_install` PEUtils method.

#### Who would you like to review this PR?

@puppetlabs/beaker (repo owners)

#### Should any of this be tested outside the normal PR CI cycle?
No.

#### Any background context you want to provide?
This method tests ancient functionality (from 3.x), has been deprecated in Beaker, and is now breaking the Classifier integration tests and blocking the current development pipeline.