### PR TITLE
PE-19888 Add workaround for 2016.1.1 console status check error

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -838,9 +838,14 @@ module Beaker
           return true if version_is_less(host['pe_ver'], '2015.2.0')
 
           attempts_limit = options[:pe_console_status_attempts] || 9
+          # Workaround for PE-14857. The classifier status service at the
+          # default level is broken in 2016.1.1. Instead we need to query
+          # the classifier service at critical level and check for service
+          # status
+          query_params = (host['pe_ver'] == '2016.1.1' ? '?level=critical' : '')
           step 'Check Console Status Endpoint' do
             match = repeat_fibonacci_style_for(attempts_limit) do
-              output = on(host, "curl -s -k https://localhost:4433/status/v1/services --cert /etc/puppetlabs/puppet/ssl/certs/#{host}.pem --key /etc/puppetlabs/puppet/ssl/private_keys/#{host}.pem --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem", :accept_all_exit_codes => true)
+              output = on(host, "curl -s -k https://localhost:4433/status/v1/services#{query_params} --cert /etc/puppetlabs/puppet/ssl/certs/#{host}.pem --key /etc/puppetlabs/puppet/ssl/private_keys/#{host}.pem --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem", :accept_all_exit_codes => true)
               begin
                 output = JSON.parse(output.stdout)
                 match = output['classifier-service']['state'] == 'running'

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1407,6 +1407,16 @@ describe ClassMixedWithDSLInstallUtils do
       subject.check_console_status_endpoint({})
     end
 
+    it 'add query param to curling url if version is 2016.1.1' do
+      unixhost[:pe_ver] = '2016.1.1'
+      allow(subject).to receive(:options).and_return({})
+      allow(subject).to receive(:version_is_less).and_return(false)
+      json_hash = '{ "classifier-service": { "state": "running" }, "rbac-service": { "state": "running" }, "activity-service":  { "state": "running" } }'
+      result = double(Beaker::Result, :stdout => "#{json_hash}")
+      expect(subject).to receive(:on).with( anything, /services\?level=critical/, anything).and_return(result)
+      subject.check_console_status_endpoint(unixhost)
+    end
+
     it 'yields false to repeat_fibonacci_style_for when conditions are not true' do
       allow(subject).to receive(:options).and_return({})
       allow(subject).to receive(:version_is_less).and_return(false)


### PR DESCRIPTION
During installation,  a classifier-service check is done in beaker-pe
to make sure console service is up and running. The classifier status
service at the default detail level is broken in 2016.1.1 (PE-14857)
and returns an error and state "unknown". The workaround is to query
the classifier-service at 'critical' level and check for the console
service status.

Please delete any headings that don't apply to this Pull Request (PR).

#### What's this PR do?
#### Who would you like to review this PR?

@puppetlabs/integration, @puppetlabs/beaker (repo owners)

#### Should any of this be tested outside the normal PR CI cycle?
#### Any background context you want to provide?
#### Questions for reviewers?
