### PR TITLE
(BKR-1085) Sign certs *before* stopping agent service

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -471,13 +471,13 @@ module Beaker
             end
           end
 
-          step "Stop puppet agents to avoid interfering with tests" do
-            stop_agent_on(all_hosts, :run_in_parallel => true)
-          end
-
           step "Sign agent certificates" do
             # This will sign all cert requests
             sign_certificate_for(agents)
+          end
+
+          step "Stop puppet agents to avoid interfering with tests" do
+            stop_agent_on(all_hosts, :run_in_parallel => true)
           end
 
           step "Run puppet to setup mcollective and pxp-agent" do

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1293,16 +1293,10 @@ describe ClassMixedWithDSLInstallUtils do
       subject.simple_monolithic_install(monolithic, [el_agent, el_agent, deb_agent, deb_agent])
     end
 
-    it 'signs all certificates at once' do
+    it 'signs certificates then stops agents to avoid interference with tests' do
       agents = [el_agent, el_agent, deb_agent, deb_agent]
-      expect(subject).to receive(:sign_certificate_for).with(agents)
-
-      subject.simple_monolithic_install(monolithic, agents)
-    end
-
-    it 'stops the agents in parallel to avoid interference with tests' do
-      agents = [el_agent, el_agent, deb_agent, deb_agent]
-      expect(subject).to receive(:stop_agent_on).with([monolithic, *agents], :run_in_parallel => true)
+      expect(subject).to receive(:sign_certificate_for).with(agents).ordered
+      expect(subject).to receive(:stop_agent_on).with([monolithic, *agents], :run_in_parallel => true).ordered
 
       subject.simple_monolithic_install(monolithic, agents)
     end


### PR DESCRIPTION
Previously, the simple_monolithic install method was installing agents,
stopping the agent service and then attempting to sign certificates.
This was failing sporadically because the agent service needs to run
enough to submit a certificate request before being stopped. This was
being handled properly in the generic install method, but the order of
operations was swapped in the monolithic install method.