### PR TITLE
(PE-20086) PE 2016.5.(0|1) should install via msi method if windows2008r2

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -759,13 +759,16 @@ module Beaker
           Beaker::DSL::InstallUtils::FeatureFlags.new(opts).flag?(flag)
         end
 
+        # @deprecated the !version_is_less(host['pe_ver'], '3.99') can be removed once we no longer support pre 2015.2.0 PE versions
         # Check if windows host is able to frictionlessly install puppet
         # @param [Beaker::Host] host that we are checking if it is possible to install frictionlessly to
         # @return [Boolean] true if frictionless is supported and not affected by known bugs
         def install_via_msi?(host)
           #windows agents from 4.0 -> 2016.1.2 were only installable via the aio method
-          #powershell2 bug was fixed in PE 2016.4.3
-          (host['platform'] =~ /windows/ && (version_is_less(host['pe_ver'], '2016.4.0') && !version_is_less(host['pe_ver'], '3.99'))) || (host['platform'] =~ /windows-2008r2/ && (version_is_less(host['pe_ver'], '2016.4.3') && !version_is_less(host['pe_ver'], '3.99')))
+          #powershell2 bug was fixed in PE 2016.4.3, and PE 2017.1.0, but not 2016.5.z.
+          (host['platform'] =~ /windows/ && (version_is_less(host['pe_ver'], '2016.4.0') && !version_is_less(host['pe_ver'], '3.99'))) ||
+            (host['platform'] =~ /windows-2008r2/ && (version_is_less(host['pe_ver'], '2016.4.3') && !version_is_less(host['pe_ver'], '3.99'))) ||
+            (host['platform'] =~ /windows-2008r2/ && (!version_is_less(host['pe_ver'], '2016.4.99') && version_is_less(host['pe_ver'], '2016.5.99') && !version_is_less(host['pe_ver'], '3.99')))
         end
 
         # True if version is greater than or equal to MEEP_CLASSIFICATION_VERSION

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -285,6 +285,22 @@ describe ClassMixedWithDSLInstallUtils do
       expect(subject.install_via_msi?(the_host)).to eq(false)
     end
 
+    it 'returns true if pe_version is 2016.5.1 and platform is windows-2008r2 bug' do
+      the_host = winhost.dup
+      the_host['roles'] = ['frictionless']
+      the_host['platform'] = 'windows-2008r2'
+      the_host['pe_ver'] = '2016.5.1'
+      expect(subject.install_via_msi?(the_host)).to eq(true)
+    end
+
+    it 'returns false if pe_version is 2017.1.0 and platform is windows-2008r2 bug' do
+      the_host = winhost.dup
+      the_host['roles'] = ['frictionless']
+      the_host['platform'] = 'windows-2008r2'
+      the_host['pe_ver'] = '2017.1.0'
+      expect(subject.install_via_msi?(the_host)).to eq(false)
+    end
+
   end
 
   describe 'higgs installer' do


### PR DESCRIPTION
Due to the timing of our LTS releases and our new major branches, PE 2016.5.0 and
PE 2016.5.1 did not get the windows2008r2 powershell fix that was done in PE-18351.
This means we need to not attempt to install frictionlessly if it is pe 2016.5.(0|1)
if the agent platform is windows2008r2.
This PR adjust the install_via_msi? method and refactors the logic in there to clean
it up a bit (it is getting tough to easily read).
It breaks the method down to three lines:
1. If the agent is older then PE 2016.4.0.
2. If the agent is windows2008r2 and is less then 2016.4.3
3. If the agent is windows2008r2 and the agent version is between 2016.4.99 and 2016.5.99.
If any of those are true then the MSI method should be used to install the agent.

#### What's this PR do?
See above
#### Who would you like to review this PR?
@puppetlabs/integration, @puppetlabs/beaker (repo owners)
#### Should any of this be tested outside the normal PR CI cycle?
Nope, once this passes we have a single cell on the weekend that will go green due to this fix. 
