### PR TITLE
MSI from URL

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -285,9 +285,14 @@ module Beaker
             # We install Puppet from the master for frictionless installs, so we don't need to *fetch* anything
             next if host['roles'].include?('frictionless') && (! version_is_less(opts[:pe_ver] || host['pe_ver'], '3.2.0'))
 
-            if host['platform'] =~ /windows/
-              fetch_pe_on_windows(host, opts)
-            elsif host['platform'] =~ /osx/
+            # Windows agents install directly over HTTP and Windows can't run master
+            next if host['platform'] =~ /windows/
+
+            # DLU: if host['platform'] =~ /windows/
+            # DLU:   fetch_pe_on_windows(host, opts)
+            # DLU: elsif host['platform'] =~ /osx/
+
+            if host['platform'] =~ /osx/
               fetch_pe_on_mac(host, opts)
             else
               fetch_pe_on_unix(host, opts)
@@ -542,8 +547,18 @@ module Beaker
             #Windows allows frictionless installs starting with PE Davis, if frictionless we need to skip this step
             elsif (host['platform'] =~ /windows/ && !(host['roles'].include?('frictionless')) || install_via_msi?(host))
               opts = { :debug => host[:pe_debug] || opts[:pe_debug] }
-              msi_path = "#{host['working_dir']}\\#{host['dist']}.msi"
-              install_msi_on(host, msi_path, {}, opts)
+              #DLU : msi_path = "#{host['working_dir']}\\#{host['dist']}.msi"
+
+              path = host['pe_dir'] || opts[:pe_dir]
+              version = host['pe_ver'] || opts[:pe_ver_win]
+              filename = "#{host['dist']}"
+              extension = ".msi"
+
+              path = "#{path}"
+              path.chomp!('/')
+              link = "#{path}/#{filename}#{extension}"
+
+              install_msi_on(host, link, {}, opts)
 
               # 1 since no certificate found and waitforcert disabled
               acceptable_exit_codes = 1

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -830,7 +830,7 @@ describe ClassMixedWithDSLInstallUtils do
       subject.fetch_pe( [eoshost], {} )
     end
 
-    it 'can push a local PE package to a windows host' do
+    it 'should not try to push a local PE package to a windows host' do
       allow( File ).to receive( :directory? ).and_return( true ) #is local
       allow( File ).to receive( :exists? ).and_return( true ) #is present
       winhost['dist'] = 'puppet-enterprise-3.0'
@@ -839,7 +839,7 @@ describe ClassMixedWithDSLInstallUtils do
       path = winhost['pe_dir']
       filename = "puppet-enterprise-#{ winhost['pe_ver'] }"
       extension = '.msi'
-      expect( subject ).to receive( :scp_to ).with( winhost, "#{ path }/#{ filename }#{ extension }", "#{ winhost['working_dir'] }/#{ filename }#{ extension }" ).once
+      expect( subject ).to receive( :scp_to ).with( winhost, "#{ path }/#{ filename }#{ extension }", "#{ winhost['working_dir'] }/#{ filename }#{ extension }" ).exactly(0).times
       subject.fetch_pe( [winhost], {} )
 
     end


### PR DESCRIPTION
* Previously, generic_install installed MSIs on Windows agents by 
   downloading an MSI to the coordinator and copying it to each 
   agent.

   It is now possible to pass a URL directly to the install_msi_on.
   Doing so avoids unnecessary copying of the MSI.

* This change inlines some of the logic from fetch_pe_on_windows 
   in generic_install and uses it to build up a URL.

   That URL is then passed to install_msi_on.

* Additionally, skip Windows platforms in fetch_pe as 
   Windows agents install directly over HTTP and Windows doesn't support 
   master.

#### Who would you like to review this PR?

@puppetlabs/integration, @puppetlabs/beaker (repo owners)

#### Any background context you want to provide?

* This is related to https://github.com/puppetlabs/beaker/pull/1383
   The changes are similar. 
