### PR TITLE
(PE-20405) On frictionless installs ensure all hosts run prepare_hosts

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -450,8 +450,8 @@ module Beaker
           all_hosts = [master, *agents]
           configure_type_defaults_on(all_hosts)
 
-          # Set PE distribution on the master, create working dir
-          prepare_hosts([master], opts)
+          # Set PE distribution on the agents, creates working directories
+          prepare_hosts(all_hosts, opts)
           fetch_pe([master], opts)
           prepare_host_installer_options(master)
           generate_installer_conf_file_for(master, [master], opts)

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1341,6 +1341,11 @@ describe ClassMixedWithDSLInstallUtils do
 
       subject.simple_monolithic_install(monolithic, agents)
     end
+
+    it "calls prepare_hosts on all hosts instead of just master" do
+      expect(subject).to receive(:prepare_hosts).with([monolithic] + [el_agent, el_agent, el_agent], {})
+      subject.simple_monolithic_install(monolithic, [el_agent, el_agent, el_agent])
+    end
   end
 
   describe 'do_higgs_install' do


### PR DESCRIPTION
Previously when there was a frictionless install prepare_hosts was
only set on the master. This meant that agents were skipped and as
a result agents did not have a working_dir set.
This caused unix machines to install on just the root directory and
caused failures on windows.