### PR TITLE
(MAINT) Fix linux masterless installation

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -551,12 +551,18 @@ module Beaker
                 :puppet_agent_version => get_puppet_agent_version(host, opts),
                 :puppet_agent_sha => host[:puppet_agent_sha] || opts[:puppet_agent_sha],
                 :pe_ver => host[:pe_ver] || opts[:pe_ver],
-                :puppet_collection => host[:puppet_collection] || opts[:puppet_collection]
+                :puppet_collection => host[:puppet_collection] || opts[:puppet_collection],
+                :pe_promoted_builds_url => host[:pe_promoted_builds_url] || opts[:pe_promoted_builds_url]
               })
               # 1 since no certificate found and waitforcert disabled
               acceptable_exit_codes = [0, 1]
               acceptable_exit_codes << 2 if opts[:type] == :upgrade
-              setup_defaults_and_config_helper_on(host, master, acceptable_exit_codes)
+              if masterless
+                configure_type_defaults_on(host)
+                on host, puppet_agent('-t'), :acceptable_exit_codes => acceptable_exit_codes
+              else
+                setup_defaults_and_config_helper_on(host, master, acceptable_exit_codes)
+              end
             #Windows allows frictionless installs starting with PE Davis, if frictionless we need to skip this step
             elsif (host['platform'] =~ /windows/ && !(host['roles'].include?('frictionless')) || install_via_msi?(host))
               opts = { :debug => host[:pe_debug] || opts[:pe_debug] }

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1143,19 +1143,21 @@ describe ClassMixedWithDSLInstallUtils do
       expect( subject ).to receive( :install_puppet_agent_pe_promoted_repo_on ).with(
         hosts[1],
         {
-          :puppet_agent_version => pa_version,
-          :puppet_agent_sha => nil,
-          :pe_ver => hosts[1][:pe_ver],
-          :puppet_collection => nil
+          :puppet_agent_version   => pa_version,
+          :puppet_agent_sha       => nil,
+          :pe_ver                 => hosts[1][:pe_ver],
+          :puppet_collection      => nil,
+          :pe_promoted_builds_url => nil
         }
       ).once
       expect( subject ).to receive( :install_puppet_agent_pe_promoted_repo_on ).with(
         hosts[2],
         {
-          :puppet_agent_version => pa_version,
-          :puppet_agent_sha => nil,
-          :pe_ver => hosts[2][:pe_ver],
-          :puppet_collection => nil
+          :puppet_agent_version   => pa_version,
+          :puppet_agent_sha       => nil,
+          :pe_ver                 => hosts[2][:pe_ver],
+          :puppet_collection      => nil,
+          :pe_promoted_builds_url => nil
         }
       ).once
       hosts.each do |host|
@@ -1220,7 +1222,8 @@ describe ClassMixedWithDSLInstallUtils do
           :puppet_agent_version => pa_version,
           :puppet_agent_sha => nil,
           :pe_ver => hosts[1][:pe_ver],
-          :puppet_collection => nil
+          :puppet_collection => nil,
+          :pe_promoted_builds_url => nil
         }
       ).once
       expect( subject ).to receive( :on ).with( hosts[2], /puppet-enterprise-installer/ ).once
@@ -1287,10 +1290,11 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive(
         :install_puppet_agent_pe_promoted_repo_on
       ).with( hosts[1], {
-        :puppet_agent_version => pa_version,
-        :puppet_agent_sha     => nil,
-        :pe_ver               => hosts[1][:pe_ver],
-        :puppet_collection    => nil
+        :puppet_agent_version   => pa_version,
+        :puppet_agent_sha       => nil,
+        :pe_ver                 => hosts[1][:pe_ver],
+        :puppet_collection      => nil,
+        :pe_promoted_builds_url => nil
       } )
       # expect( subject ).to receive( :on ).with( hosts[2], /puppet-enterprise-installer/ ).once
       hosts.each do |host|


### PR DESCRIPTION
Since I had some issues cleaning up my commit history on #16 I have opened this PR.

Issue:
Setting up a masterless linux client would fail with the following error:

Exited: 1
Error: puppet config set takes 2 arguments, but you gave 1
Error: Try 'puppet help config set' for usage

This is the same issue as described in #1 but for linux operating systems.

Also if you set the pe_promoted_builds_url in you nodeset yml file it was not passed on to the install_puppet_agent_pe_promoted_repo_on function so you couldn't point beaker to a different installation source from which to get the client installation repositories. (it would default to the pm.puppetlabs.com url)