### PR TITLE
PE-20610 Fix install failure on windows for old pe versions

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -423,6 +423,8 @@ module Beaker
           return :generic if hosts.map {|host| host['pe_ver']}.uniq.length > 1
           return :generic if opts[:type] == :upgrade
           return :generic if version_is_less(opts[:pe_ver] || hosts.first['pe_ver'], '2016.4')
+          #PE-20610 Do a generic install for old versions on windows that needs msi install because of PE-18351
+          return :generic if hosts.any? {|host| host['platform'] =~ /windows/ && install_via_msi?(host)}
 
           mono_roles = ['master', 'database', 'dashboard']
           if has_all_roles?(hosts.first, mono_roles) && hosts.drop(1).all? {|host| host['roles'].include?('frictionless')}

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -943,6 +943,11 @@ describe ClassMixedWithDSLInstallUtils do
       hosts = [monolithic, master, agent, agent, agent]
       expect(subject.determine_install_type(hosts, {})).to eq(:generic)
     end
+    it 'identifies an install that requires windows msi install as generic' do
+      win_agent = make_host('agent', :pe_ver => '2016.4.0', :platform => 'win-2008r2', :roles => ['frictionless'])
+      hosts = [monolithic, agent, win_agent]
+      expect(subject.determine_install_type(hosts, {})).to eq(:generic)
+    end
   end
 
   describe '#deploy_frictionless_to_master' do


### PR DESCRIPTION
Added logic to use the old generic_install method on windows when
installing old pe versions that requires an msi install because of
powershell2 issue PE-18351. The newly added simple_monolithic_install
does not have a check for those conditions and proceeds with
frictionless installation on those hosts which fails.



