### PR TITLE
(QENG-5040) Run puppet after simplified mono install

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -485,6 +485,7 @@ module Beaker
           end
 
           step "Run puppet to setup mcollective and pxp-agent" do
+            on(master, puppet_agent('-t'), :acceptable_exit_codes => [0,2])
             run_puppet_on_non_infrastructure_nodes(all_hosts)
 
             #Workaround for windows frictionless install, see BKR-943 for the reason


### PR DESCRIPTION
Previous to this commit, the new simplified mono install method was not
running puppet on the master node in a mono only scenario. If the
install included agents not of the masters OS, then puppet would of been
ran due to needing to add pe_repo classes. In the scenario of mono
master only, if puppet is not ran, then setup is not considered complete
due to exported resources, mcollective and facts not being setup yet.
This would cause numerous issues, such as no facts in puppetdb (so
anyaltic tests for example would fail) until a test somewhere in the
pipeline ran puppet agent on the master node.
This commit adds a call outside of the parallel agent run on non infra
agents due to the fact that with exported resources, the classifier
service will restart, so need to run the master first, then after that
all the agents can run.

Please delete any headings that don't apply to this Pull Request (PR).

#### What's this PR do?
#### Who would you like to review this PR?

@puppetlabs/integration, @puppetlabs/beaker (repo owners)

#### Should any of this be tested outside the normal PR CI cycle?
#### Any background context you want to provide?
#### Questions for reviewers?
