### PR TITLE
(QENG-5095) Use `current` endpoint for frictionless agent

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -113,10 +113,10 @@ module Beaker
               "powershell -c \"cd #{host['working_dir']};[Net.ServicePointManager]::ServerCertificateValidationCallback = {\\$true};\\$webClient = New-Object System.Net.WebClient;\\$webClient.DownloadFile('https://#{master}:8140/packages/#{version}/install.ps1', '#{host['working_dir']}/install.ps1');#{host['working_dir']}/install.ps1 -verbose #{frictionless_install_opts.join(' ')}\""
             elsif host['platform'] =~ /aix/ then
               curl_opts = '--tlsv1 -O'
-              "cd #{host['working_dir']} && curl #{curl_opts} https://#{master}:8140/packages/#{version}/install.bash && bash#{pe_debug} install.bash #{frictionless_install_opts.join(' ')}".strip
+              "cd #{host['working_dir']} && curl #{curl_opts} https://#{master}:8140/packages/current/install.bash && bash#{pe_debug} install.bash #{frictionless_install_opts.join(' ')}".strip
             else
               curl_opts = '--tlsv1 -kO'
-              "cd #{host['working_dir']} && curl #{curl_opts} https://#{master}:8140/packages/#{version}/install.bash && bash#{pe_debug} install.bash #{frictionless_install_opts.join(' ')}".strip
+              "cd #{host['working_dir']} && curl #{curl_opts} https://#{master}:8140/packages/current/install.bash && bash#{pe_debug} install.bash #{frictionless_install_opts.join(' ')}".strip
             end
           elsif host['platform'] =~ /osx/
             version = host['pe_ver'] || opts[:pe_ver]

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -203,7 +203,7 @@ describe ClassMixedWithDSLInstallUtils do
       the_host['pe_ver'] = '3.8.0'
       the_host['pe_installer'] = 'puppet-enterprise-installer'
       the_host['roles'] = ['frictionless']
-      expect( subject.installer_cmd( the_host, {} ) ).to be ===  "cd /tmp && curl --tlsv1 -kO https://testmaster:8140/packages/3.8.0/install.bash && bash install.bash"
+      expect( subject.installer_cmd( the_host, {} ) ).to be ===  "cd /tmp && curl --tlsv1 -kO https://testmaster:8140/packages/current/install.bash && bash install.bash"
     end
 
     it 'generates a unix PE frictionless install command for a unix host with role "frictionless" and "frictionless_options"' do
@@ -213,7 +213,7 @@ describe ClassMixedWithDSLInstallUtils do
       the_host['pe_installer'] = 'puppet-enterprise-installer'
       the_host['roles'] = ['frictionless']
       the_host['frictionless_options'] = { 'main' => { 'dns_alt_names' => 'puppet' } }
-      expect( subject.installer_cmd( the_host, {} ) ).to be ===  "cd /tmp && curl --tlsv1 -kO https://testmaster:8140/packages/3.8.0/install.bash && bash install.bash main:dns_alt_names=puppet"
+      expect( subject.installer_cmd( the_host, {} ) ).to be ===  "cd /tmp && curl --tlsv1 -kO https://testmaster:8140/packages/current/install.bash && bash install.bash main:dns_alt_names=puppet"
     end
 
     it 'generates a osx PE install command for a osx host' do
@@ -250,7 +250,7 @@ describe ClassMixedWithDSLInstallUtils do
       the_host['pe_installer'] = 'puppet-enterprise-installer'
       the_host['roles'] = ['frictionless']
       the_host[:pe_debug] = true
-      expect( subject.installer_cmd( the_host, {} ) ).to be === "cd /tmp && curl --tlsv1 -kO https://testmaster:8140/packages/3.8.0/install.bash && bash -x install.bash"
+      expect( subject.installer_cmd( the_host, {} ) ).to be === "cd /tmp && curl --tlsv1 -kO https://testmaster:8140/packages/current/install.bash && bash -x install.bash"
     end
   end
 


### PR DESCRIPTION
Previous to this commit, the url constructed for frictionless agent
installs attempted to use the hosts `pe_ver` variable for getting the
exact URL of the simplified install script. This was causing issues with
PEZ builds due to the different pe_ver in the filename (for downloading
the tarball) and the actual pe version.
This commit updates the url to just use the `current` endpoint instead
of the version, which mimics our install documentation. This won't
really remove the ability of installing an older version via this method
considering the logic for adding pe_repo classes didn't support passing
a specific pe_ver / agent version to pe_repo.

Please delete any headings that don't apply to this Pull Request (PR).

#### What's this PR do?
#### Who would you like to review this PR?

@puppetlabs/integration, @puppetlabs/beaker (repo owners)

#### Should any of this be tested outside the normal PR CI cycle?
#### Any background context you want to provide?
#### Questions for reviewers?
