### PR TITLE
Maint/master/second agent run for simple installs

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -494,6 +494,10 @@ module Beaker
               on(agent, puppet("resource file \"#{client_datadir}\" ensure=absent force=true"))
             end
           end
+
+          step "Run puppet a second time on the primary to populate services.conf (PE-19054)" do
+            on(master, puppet_agent('-t'), :acceptable_exit_codes => [0,2])
+          end
         end
 
         def generic_install hosts, opts = {}


### PR DESCRIPTION
(maint,PE-19054) Add second agent run to complete simple mono install ￼…

HA tests in prs (puppet_enterprise module) have been failing because
services.conf is not configured. Two puppet agent runs post install are
required to achieve this. The first populates puppetdb with catalog
data; the second queries that to assemble the services.conf file.

The simple_monolithic_install() function was only running puppet-agent
once on the primary. This was causing subsequent ha tests to fail
because they could not provision properly without services.conf.

This PR adds a second puppet run so that this final configuration is
handled.