### PR TITLE
(QENG-5095) Windows frictionless uses current url

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -110,7 +110,7 @@ module Beaker
 
             pe_debug = host[:pe_debug] || opts[:pe_debug] ? ' -x' : ''
             if host['platform'] =~ /windows/ then
-              "powershell -c \"cd #{host['working_dir']};[Net.ServicePointManager]::ServerCertificateValidationCallback = {\\$true};\\$webClient = New-Object System.Net.WebClient;\\$webClient.DownloadFile('https://#{master}:8140/packages/#{version}/install.ps1', '#{host['working_dir']}/install.ps1');#{host['working_dir']}/install.ps1 -verbose #{frictionless_install_opts.join(' ')}\""
+              "powershell -c \"cd #{host['working_dir']};[Net.ServicePointManager]::ServerCertificateValidationCallback = {\\$true};\\$webClient = New-Object System.Net.WebClient;\\$webClient.DownloadFile('https://#{master}:8140/packages/current/install.ps1', '#{host['working_dir']}/install.ps1');#{host['working_dir']}/install.ps1 -verbose #{frictionless_install_opts.join(' ')}\""
             elsif host['platform'] =~ /aix/ then
               curl_opts = '--tlsv1 -O'
               "cd #{host['working_dir']} && curl #{curl_opts} https://#{master}:8140/packages/current/install.bash && bash#{pe_debug} install.bash #{frictionless_install_opts.join(' ')}".strip


### PR DESCRIPTION
Previous to this commit, the url constructed for frictionless agent
installs attempted to use the hosts `pe_ver` variable for getting the
exact URL of the simplified install script. This was causing issues with
PEZ builds due to the different pe_ver in the filename (for downloading
the tarball) and the actual pe version.
This commit updates the url to just use the `current` endpoint instead
of the version, which mimics our install documentation. This won't
really remove the ability of installing an older version via this method
considering the logic for adding pe_repo classes didn't support passing
a specific pe_ver / agent version to pe_repo.

Please delete any headings that don't apply to this Pull Request (PR).

#### What's this PR do?
#### Who would you like to review this PR?

@puppetlabs/integration, @puppetlabs/beaker (repo owners)

#### Should any of this be tested outside the normal PR CI cycle?
#### Any background context you want to provide?
#### Questions for reviewers?
