### PR TITLE
(PE-20966) Add retry to deploy_frictionless_agent_repo

### DIFF
--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -978,7 +978,7 @@ describe ClassMixedWithDSLInstallUtils do
     let(:node_group) { {} }
 
     before :each do
-      allow(subject).to receive(:on)
+      allow(subject).to receive(:retry_on)
 
       allow(subject).to receive(:hosts).and_return([master, agent])
       allow(Scooter::HttpDispatchers::ConsoleDispatcher).to receive(:new).and_return(dispatcher)


### PR DESCRIPTION
Previous to this commit, when adding agents via pe_repo to the master,
the puppet agent runs would sometimes fail with various curl errors due
to network blips. This would end up causing transients in our testing
pipelines that required manual triaging and re-running of jobs.
This commit works around the network transients by using beakers
`retry_on` method to retry the puppet agent run up to 3 times before
failing out.

Please delete any headings that don't apply to this Pull Request (PR).

#### What's this PR do?
#### Who would you like to review this PR?

@puppetlabs/integration, @puppetlabs/beaker (repo owners)

#### Should any of this be tested outside the normal PR CI cycle?
#### Any background context you want to provide?
#### Questions for reviewers?
