### PR TITLE
Added log message to long running section

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -507,7 +507,9 @@ module Beaker
           fetch_pe([master], opts)
           prepare_host_installer_options(master)
           generate_installer_conf_file_for(master, [master], opts)
-          on master, installer_cmd(master, opts)
+          step "Install PE on master" do
+            on master, installer_cmd(master, opts)
+          end
 
           step "Setup frictionless installer on the master" do
             agents.each do |agent|


### PR DESCRIPTION
Right before a long pause in the install run, was a message about scp'ing a file.  Clearly that wasn't taking all the time.
Turns out that pe was being installed on the master right after that, but no message was logged.
So added a message to log that fact and make it clear.


@puppetlabs/integration, @puppetlabs/beaker (repo owners)

