### PR TITLE
(maint) Allow unauthenticated packages on debian based systems

### DIFF
--- a/lib/beaker-pe/pe-client-tools/install_helper.rb
+++ b/lib/beaker-pe/pe-client-tools/install_helper.rb
@@ -98,6 +98,7 @@ module Beaker
               )
 
               scp_to host, list, '/etc/apt/sources.list.d'
+              create_remote_file(host, "/etc/apt/apt.conf.d/99trust-all", 'APT::Get::AllowUnauthenticated "true";')
               on host, 'apt-get update'
             else
               host.logger.notify("No repository installation step for #{platform} yet...")

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -200,17 +200,17 @@ describe ClassMixedWithDSLInstallUtils do
     end
 
     it 'generates a unix PE frictionless install command without cert verification' do
-      expect( subject.frictionless_agent_installer_cmd( host, {}, '2016.4.0' ) ).to eq("export FRICTIONLESS_TRACE=true; cd /tmp && curl --tlsv1 -O -k https://testmaster:8140/packages/current/install.bash && bash install.bash")
+      expect( subject.frictionless_agent_installer_cmd( host, {}, '2016.4.0' ) ).to eq("FRICTIONLESS_TRACE='true'; export FRICTIONLESS_TRACE; cd /tmp && curl --tlsv1 -O -k https://testmaster:8140/packages/current/install.bash && bash install.bash")
     end
 
     it 'generates a unix PE frictionless install command with cert verification' do
       host['use_puppet_ca_cert'] = true
-      expect( subject.frictionless_agent_installer_cmd( host, {}, '2016.4.0' ) ).to eq("export FRICTIONLESS_TRACE=true; cd /tmp && curl --tlsv1 -O --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem https://testmaster:8140/packages/current/install.bash && bash install.bash")
+      expect( subject.frictionless_agent_installer_cmd( host, {}, '2016.4.0' ) ).to eq("FRICTIONLESS_TRACE='true'; export FRICTIONLESS_TRACE; cd /tmp && curl --tlsv1 -O --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem https://testmaster:8140/packages/current/install.bash && bash install.bash")
     end
 
     it 'generates a unix PE frictionless install command without cert verification on aix' do
       host['platform'] = 'aix-61-power'
-      expect( subject.frictionless_agent_installer_cmd( host, {}, '2016.4.0' ) ).to eq("export FRICTIONLESS_TRACE=true; cd /tmp && curl --tlsv1 -O https://testmaster:8140/packages/current/install.bash && bash install.bash")
+      expect( subject.frictionless_agent_installer_cmd( host, {}, '2016.4.0' ) ).to eq("FRICTIONLESS_TRACE='true'; export FRICTIONLESS_TRACE; cd /tmp && curl --tlsv1 -O https://testmaster:8140/packages/current/install.bash && bash install.bash")
     end
 
     it 'generates a PS1 frictionless install command for windows' do
@@ -259,7 +259,7 @@ describe ClassMixedWithDSLInstallUtils do
       the_host['pe_ver'] = '3.8.0'
       the_host['pe_installer'] = 'puppet-enterprise-installer'
       the_host['roles'] = ['frictionless']
-      expect( subject.installer_cmd( the_host, {} ) ).to be ===  "export FRICTIONLESS_TRACE=true; cd /tmp && curl --tlsv1 -O -k https://testmaster:8140/packages/current/install.bash && bash install.bash"
+      expect( subject.installer_cmd( the_host, {} ) ).to be ===  "FRICTIONLESS_TRACE='true'; export FRICTIONLESS_TRACE; cd /tmp && curl --tlsv1 -O -k https://testmaster:8140/packages/current/install.bash && bash install.bash"
     end
 
     it 'generates a unix PE frictionless install command for a unix host with role "frictionless" and "frictionless_options"' do
@@ -269,7 +269,7 @@ describe ClassMixedWithDSLInstallUtils do
       the_host['pe_installer'] = 'puppet-enterprise-installer'
       the_host['roles'] = ['frictionless']
       the_host['frictionless_options'] = { 'main' => { 'dns_alt_names' => 'puppet' } }
-      expect( subject.installer_cmd( the_host, {} ) ).to be ===  "export FRICTIONLESS_TRACE=true; cd /tmp && curl --tlsv1 -O -k https://testmaster:8140/packages/current/install.bash && bash install.bash main:dns_alt_names=puppet"
+      expect( subject.installer_cmd( the_host, {} ) ).to be ===  "FRICTIONLESS_TRACE='true'; export FRICTIONLESS_TRACE; cd /tmp && curl --tlsv1 -O -k https://testmaster:8140/packages/current/install.bash && bash install.bash main:dns_alt_names=puppet"
     end
 
     it 'generates a osx PE install command for a osx host' do
@@ -306,7 +306,7 @@ describe ClassMixedWithDSLInstallUtils do
       the_host['pe_installer'] = 'puppet-enterprise-installer'
       the_host['roles'] = ['frictionless']
       the_host[:pe_debug] = true
-      expect( subject.installer_cmd( the_host, {} ) ).to be === "export FRICTIONLESS_TRACE=true; cd /tmp && curl --tlsv1 -O -k https://testmaster:8140/packages/current/install.bash && bash -x install.bash"
+      expect( subject.installer_cmd( the_host, {} ) ).to be === "FRICTIONLESS_TRACE='true'; export FRICTIONLESS_TRACE; cd /tmp && curl --tlsv1 -O -k https://testmaster:8140/packages/current/install.bash && bash -x install.bash"
     end
   end
 

--- a/spec/beaker-pe/pe-client-tools/installer_helper_spec.rb
+++ b/spec/beaker-pe/pe-client-tools/installer_helper_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 class ClassPEClientToolsMixedWithPatterns
   include Beaker::DSL::InstallUtils::PEClientTools
+  include Beaker::DSL::Helpers::HostHelpers
   include Beaker::DSL::Patterns
 end
 


### PR DESCRIPTION
Previously `install_dev_repos_on` only installed the dev repos on a
system.

Unfortunately, the dev repos are unsigned and apt-get
installation will fail for packages provided by the dev repo. The
console services all have copied this method and updated it to allow
unauthenticated packages. Doing so is required for a clean PE
installation using the dev repos.

This patch updates the upstream method in this repo to be functionally
equivalent to the copied methods used in downstream consumers, allowing
those downstream consumers to no longer maintain copy-pasted versions of
this method.

Please delete any headings that don't apply to this Pull Request (PR).

#### What's this PR do?
#### Who would you like to review this PR?

@puppetlabs/integration, @puppetlabs/beaker (repo owners)

#### Should any of this be tested outside the normal PR CI cycle?
#### Any background context you want to provide?
#### Questions for reviewers?

I'm unsure how to run the tests for this project!
