### PR TITLE
Issue/pe 21368 support frictionless install with ca cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ things:
 2. put a `require 'beaker-pe'` statement in your tests/code that need
   beaker-pe-specific functionality
 
+# Gem Installing
+Spec tests require a version of scooter that is private. Execute
+`export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net` prior to running
+`bundle install --path .bundle/gems/`.
+
 # Spec Testing
 
 Spec tests all live under the `spec` folder.  These are the default rake task, &

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -95,7 +95,7 @@ module Beaker
               agent_ca_pem_dir = "#{host['puppetpath']}/ssl/certs"
               master_ca_pem_path = "/etc/puppetlabs/puppet/ssl/certs/ca.pem"
               scp_from(master, master_ca_pem_path , @cert_cache_dir) unless File.exist?(local_cert_copy)
-              on(host, "mkdir -p #{ca_pem_dir}")
+              on(host, "mkdir -p #{agent_ca_pem_dir}")
               scp_to(host, local_cert_copy, agent_ca_pem_dir)
             end
           end

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -247,22 +247,22 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'generates a PS1 frictionless install command for windows' do
       host['platform'] = 'windows-2012-64'
+      host['puppetpath'] = '/PuppetLabs/puppet/etc'
       host['use_puppet_ca_cert'] = true
       expecting = "powershell -c \"" +
       [
         "cd /tmp",
-        "$callback = {param($sender,[System.Security.Cryptography.X509Certificates.X509Certificate]$certificate,[System.Security.Cryptography.X509Certificates.X509Chain]$chain,[System.Net.Security.SslPolicyErrors]$sslPolicyErrors)",
-        "$CertificateType=[System.Security.Cryptography.X509Certificates.X509Certificate2]",
-        "$CACert=$CertificateType::CreateFromCertFile('C:\\ProgramData\\PuppetLabs\\puppet\\etc\\ssl\\certs\\ca_cert.pem') -as $CertificateType",
-        "$chain.ChainPolicy.ExtraStore.Add($CACert)",
-        "return $chain.Build($certificate)}",
-        "[Net.ServicePointManager]::ServerCertificateValidationCallback = $callback",
+        "\\$callback = {param(\\$sender,[System.Security.Cryptography.X509Certificates.X509Certificate]\\$certificate,[System.Security.Cryptography.X509Certificates.X509Chain]\\$chain,[System.Net.Security.SslPolicyErrors]\\$sslPolicyErrors)",
+        "\\$CertificateType=[System.Security.Cryptography.X509Certificates.X509Certificate2]",
+        "\\$CACert=\\$CertificateType::CreateFromCertFile('/PuppetLabs/puppet/etc/ssl/certs/ca.pem') -as \\$CertificateType",
+        "\\$chain.ChainPolicy.ExtraStore.Add(\\$CACert)",
+        "return \\$chain.Build(\\$certificate)}",
+        "[Net.ServicePointManager]::ServerCertificateValidationCallback = \\$callback",
         "\\$webClient = New-Object System.Net.WebClient",
         "\\$webClient.DownloadFile('https://testmaster:8140/packages/current/install.ps1', '#{host['working_dir']}/install.ps1')",
         "/tmp/install.ps1 -verbose -UsePuppetCA"
       ].join(";") +
       "\""
-
       expect( subject.frictionless_agent_installer_cmd( host, {}, '2016.4.0' ) ).to eq(expecting)
     end
   end
@@ -280,6 +280,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'installs ca.pem if use_puppet_ca_cert is true' do
       host['use_puppet_ca_cert'] = true
+      host['puppetpath'] = '/etc/puppetlabs/puppet'
       expect(Dir).to receive(:mktmpdir).with('master_ca_cert').and_return('/tmp/master_ca_cert_random')
       expect(subject).to receive(:on).with(host, 'mkdir -p /etc/puppetlabs/puppet/ssl/certs')
       expect(subject).to receive(:scp_from).with('testmaster', '/etc/puppetlabs/puppet/ssl/certs/ca.pem', %r{/tmp/master_ca_cert_random})


### PR DESCRIPTION
This PR will allow us to test Windows agent workflows that use certificates that have been pre-installed or ignore the certificate validation (the existing functionality). This should leverage the functionality that was added in PE-21277 to use +use_puppet_ca_cert+ flag in your beaker host.cfg.

@jpartlow, @mwbutcher 
@puppetlabs/integration, @puppetlabs/beaker (repo owners)

This change assumes that the function scp_from works on Windows and will install the certificate in the correct location. 

See PR #79 for additional context.
