### PR TITLE
(ORCH-1986) add helper for puppet-task

### DIFF
--- a/lib/beaker-pe/pe-client-tools/executable_helper.rb
+++ b/lib/beaker-pe/pe-client-tools/executable_helper.rb
@@ -61,6 +61,15 @@ module Beaker
           Private.new.tool(:query, *args, &block)
         end
 
+        # puppet-task helper win/lin/osx
+        # @param [BEAKER::Host] host The SUT that should run the puppet-task command
+        # @param [String] args The arguments to puppet-task
+        # @param [Hash] opts options hash to the Beaker Command
+        # @param [Block] &block optional block
+        def puppet_task_on(*args, &block)
+          Private.new.tool(:task, *args, &block)
+        end
+
         # Logs a user in on a SUT with puppet-access/RBAC API (windows)
         # @param [Beaker::Host] host The SUT to perform the login on
         # @param [Scooter::HttpDispatchers::ConsoleDispatcher] credentialed_dispatcher A Scooter dispatcher that has credentials for the user

--- a/spec/beaker-pe/pe-client-tools/executable_helper_spec.rb
+++ b/spec/beaker-pe/pe-client-tools/executable_helper_spec.rb
@@ -52,6 +52,12 @@ describe MixedWithExecutableHelper do
     it_behaves_like 'pe-client-tool'
   end
 
+  context 'puppet-task' do
+    let(:tool) {'task'}
+
+    it_behaves_like 'pe-client-tool'
+  end
+
   it 'has a method to login with puppet access' do
     expect(subject.respond_to?('login_with_puppet_access_on')).not_to be(false)
   end


### PR DESCRIPTION
This PR creates the `puppet_task_on` that will assist in running tasks from a client on Linux/Mac/Windows.  The new task command is part of the Orchestrator-client in the pe-client-tools package.  
