### PR TITLE
Fix agent installation failure caused by previous commit

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -598,13 +598,15 @@ module Beaker
 
             if agent_only_check_needed && hosts_agent_only.include?(host) || install_via_msi?(host)
               host['type'] = 'aio'
-              install_puppet_agent_pe_promoted_repo_on(host, {
+              install_params = {
                 :puppet_agent_version => get_puppet_agent_version(host, opts),
                 :puppet_agent_sha => host[:puppet_agent_sha] || opts[:puppet_agent_sha],
                 :pe_ver => host[:pe_ver] || opts[:pe_ver],
                 :puppet_collection => host[:puppet_collection] || opts[:puppet_collection],
                 :pe_promoted_builds_url => host[:pe_promoted_builds_url] || opts[:pe_promoted_builds_url]
-              })
+              }
+              install_params.delete(:pe_promoted_builds_url) if install_params[:pe_promoted_builds_url].nil?
+              install_puppet_agent_pe_promoted_repo_on(host, install_params)
               # 1 since no certificate found and waitforcert disabled
               acceptable_exit_codes = [0, 1]
               acceptable_exit_codes << 2 if opts[:type] == :upgrade

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1216,10 +1216,12 @@ describe ClassMixedWithDSLInstallUtils do
       hosts = make_hosts({
         :pe_ver => '4.0',
         :roles => ['agent'],
-      }, 3)
+      }, 4)
       hosts[0][:roles] = ['master', 'database', 'dashboard']
       hosts[1][:platform] = 'windows'
       hosts[2][:platform] = Beaker::Platform.new('el-6-x86_64')
+      hosts[2][:pe_promoted_builds_url] = nil
+      hosts[3][:pe_promoted_builds_url] = 'test-url'
 
       allow( subject ).to receive( :hosts ).and_return( hosts )
       allow( subject ).to receive( :options ).and_return(Beaker::Options::Presets.new.presets)
@@ -1252,7 +1254,6 @@ describe ClassMixedWithDSLInstallUtils do
           :puppet_agent_sha       => nil,
           :pe_ver                 => hosts[1][:pe_ver],
           :puppet_collection      => nil,
-          :pe_promoted_builds_url => nil
         }
       ).once
       expect( subject ).to receive( :install_puppet_agent_pe_promoted_repo_on ).with(
@@ -1262,7 +1263,16 @@ describe ClassMixedWithDSLInstallUtils do
           :puppet_agent_sha       => nil,
           :pe_ver                 => hosts[2][:pe_ver],
           :puppet_collection      => nil,
-          :pe_promoted_builds_url => nil
+        }
+      ).once
+      expect( subject ).to receive( :install_puppet_agent_pe_promoted_repo_on ).with(
+        hosts[3],
+        {
+          :puppet_agent_version   => pa_version,
+          :puppet_agent_sha       => nil,
+          :pe_ver                 => hosts[3][:pe_ver],
+          :puppet_collection      => nil,
+          :pe_promoted_builds_url => 'test-url'
         }
       ).once
       hosts.each do |host|
@@ -1328,7 +1338,6 @@ describe ClassMixedWithDSLInstallUtils do
           :puppet_agent_sha => nil,
           :pe_ver => hosts[1][:pe_ver],
           :puppet_collection => nil,
-          :pe_promoted_builds_url => nil
         }
       ).once
       expect( subject ).to receive( :on ).with( hosts[2], /puppet-enterprise-installer/ ).once
@@ -1399,7 +1408,6 @@ describe ClassMixedWithDSLInstallUtils do
         :puppet_agent_sha       => nil,
         :pe_ver                 => hosts[1][:pe_ver],
         :puppet_collection      => nil,
-        :pe_promoted_builds_url => nil
       } )
       # expect( subject ).to receive( :on ).with( hosts[2], /puppet-enterprise-installer/ ).once
       hosts.each do |host|


### PR DESCRIPTION
Previous commit was setting the options['pe_promoted_builds_url']
to nil in certain cases causing failure in constructing the correct
agent download url

