### PR TITLE
Revert "PE-22051 Changes for adding loadbalancer to LEI job"

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -101,30 +101,6 @@ module Beaker
           end
         end
 
-        # Return agent nodes with 'lb_connect' role that are not loadbalancers
-        def loadbalancer_connecting_agents
-          lb_connect_nodes = select_hosts(roles: ['lb_connect'])
-          lb_connect_agents = lb_connect_nodes.reject { |h| h['roles'].include?('loadbalancer')}
-        end
-
-        # Returns true if loadbalncer exists and is configured with 'lb_connect' role
-        def lb_connect_loadbalancer_exists?
-          if (any_hosts_as?('loadbalancer'))
-            lb_node = select_hosts(roles: ['loadbalancer'])
-            lb_node.first['roles'].include?('lb_connect')
-          end
-        end
-
-        #Returns loadbalancer if host is an agent and loadbalancer has lb_connect role
-        #@param [Host] agent host with lb_connect role
-        def get_lb_downloadhost(host)
-          downloadhost = master
-          if( ! host['roles'].include?('loadbalancer') &&  lb_connect_loadbalancer_exists?)
-            downloadhost = loadbalancer
-          end
-          downloadhost
-        end
-
         # Generate the command line string needed to from a frictionless puppet-agent
         # install on this host in a PE environment.
         #
@@ -148,14 +124,6 @@ module Beaker
             end
           end
 
-          # If this is an agent node configured to connect to the loadbalancer
-          # using 'lb_connect' role, then use loadbalancer in the download url
-          # instead of master (PE-22051)
-          downloadhost = master
-          if( host['roles'].include?('lb_connect'))
-            downloadhost = get_lb_downloadhost(host)
-          end
-
           pe_debug = host[:pe_debug] || opts[:pe_debug] ? ' -x' : ''
           use_puppet_ca_cert = host[:use_puppet_ca_cert] || opts[:use_puppet_ca_cert]
 
@@ -167,7 +135,7 @@ module Beaker
               cert_validator = '[Net.ServicePointManager]::ServerCertificateValidationCallback = {\\$true}'
             end
 
-            cmd = %Q{powershell -c "cd #{host['working_dir']};#{cert_validator};\\$webClient = New-Object System.Net.WebClient;\\$webClient.DownloadFile('https://#{downloadhost}:8140/packages/current/install.ps1', '#{host['working_dir']}/install.ps1');#{host['working_dir']}/install.ps1 -verbose #{frictionless_install_opts.join(' ')}"}
+            cmd = %Q{powershell -c "cd #{host['working_dir']};#{cert_validator};\\$webClient = New-Object System.Net.WebClient;\\$webClient.DownloadFile('https://#{master}:8140/packages/current/install.ps1', '#{host['working_dir']}/install.ps1');#{host['working_dir']}/install.ps1 -verbose #{frictionless_install_opts.join(' ')}"}
           else
             curl_opts = %w{--tlsv1 -O}
             if use_puppet_ca_cert
@@ -176,7 +144,7 @@ module Beaker
               curl_opts << '-k'
             end
 
-            cmd = "FRICTIONLESS_TRACE='true'; export FRICTIONLESS_TRACE; cd #{host['working_dir']} && curl #{curl_opts.join(' ')} https://#{downloadhost}:8140/packages/current/install.bash && bash#{pe_debug} install.bash #{frictionless_install_opts.join(' ')}".strip
+            cmd = "FRICTIONLESS_TRACE='true'; export FRICTIONLESS_TRACE; cd #{host['working_dir']} && curl #{curl_opts.join(' ')} https://#{master}:8140/packages/current/install.bash && bash#{pe_debug} install.bash #{frictionless_install_opts.join(' ')}".strip
           end
 
           return cmd
@@ -408,41 +376,33 @@ module Beaker
           else
             _console_dispatcher = get_console_dispatcher_for_beaker_pe!
 
-            # Add pe_repo packages to 'PE Master' group
-            # This change will alow us to test the standard workflow where we add pe_repo packages
-            # to PE Master group itself. This will also make it easy to download the packages to
-            # compilemasters(PE-22051)
-            # Previosuly, we were creating a new node group 'Beaker Frictionless Agent' and adding
-            # pe_repo packages to that group
-            #
-            node_group = _console_dispatcher.get_node_group_by_name('PE Master')
+            # Check if we've already created a frictionless agent node group
+            # to avoid errors creating the same node group when the beaker hosts file contains
+            # multiple hosts with the same platform
+            node_group = _console_dispatcher.get_node_group_by_name('Beaker Frictionless Agent')
+            if node_group.nil? || node_group.empty?
+              node_group = {}
+              node_group['name'] = "Beaker Frictionless Agent"
+              # Pin the master to the node
+              node_group['rule'] = [ "and",  [ '=', 'name', master.to_s ]]
+              node_group['classes'] ||= {}
+            end
 
             # add the pe_repo platform class if it's not already present
-            if (node_group)
-              if( ! node_group['classes'].include?(klass))
-                node_group['classes'][klass] = {}
-                _console_dispatcher.create_new_node_group_model(node_group)
+            if ! node_group['classes'].include?(klass)
+              node_group['classes'][klass] = {}
 
-                # The puppet agent run that will download the agent tarballs to the master can sometimes fail with
-                # curl errors if there is a network hiccup. Use beakers `retry_on` method to retry up to
-                # three times to avoid failing the entire test pipeline due to a network blip
-                retry_opts = {
-                  :desired_exit_codes => [0,2],
-                  :max_retries => 3,
-                  # Beakers retry_on method wants the verbose value to be a string, not a bool.
-                  :verbose => 'true'
-                }
-                retry_on(master, puppet("agent -t"), retry_opts)
-
-                # Download the agent tarballs to compile masters
-                hosts.each do |h|
-                  if h['roles'].include?('compile_master')
-                    retry_on(h, puppet("agent -t"), retry_opts)
-                  end
-                end
-              end
-            else
-              raise "Failed to add pe_repo packages, PE Master node group is not available"
+              _console_dispatcher.create_new_node_group_model(node_group)
+              # The puppet agent run that will download the agent tarballs to the master can sometimes fail with
+              # curl errors if there is a network hiccup. Use beakers `retry_on` method to retry up to
+              # three times to avoid failing the entire test pipeline due to a network blip
+              retry_opts = {
+                :desired_exit_codes => [0,2],
+                :max_retries => 3,
+                # Beakers retry_on method wants the verbose value to be a string, not a bool.
+                :verbose => 'true'
+              }
+              retry_on(master, puppet("agent -t"), retry_opts)
             end
           end
         end
@@ -1589,34 +1549,6 @@ module Beaker
             end
           end
         end
-
-        # Method to install just the agent nodes
-        # This method can be called only after installing PE on all other nodes
-        # including infrastructure nodes, loadbalancer, hubs and spokes
-        # PE-22051
-        # @param [Array] agent only nodes from Beaker hosts
-        # @param [Hash] opts The Beaker options hash
-        #
-        def install_agents_only_on(agentnodes, opts)
-          if( ! agentnodes.empty?)
-            configure_type_defaults_on(agentnodes)
-             agentnodes.each  do |host|
-               if host['platform'] != master['platform']
-                 deploy_frictionless_to_master(host)
-               end
-               install_ca_cert_on(host, opts)
-               on(host, installer_cmd(host, opts))
-             end
-             sign_certificate_for(agentnodes)
-             stop_agent_on(agentnodes, :run_in_parallel => true)
-             on agentnodes, puppet_agent('-t'), :acceptable_exit_codes => [0,2], :run_in_parallel => true
-             agentnodes.select {|agent| agent['platform'] =~ /windows/}.each do |agent|
-               client_datadir = agent.puppet['client_datadir']
-               on(agent, puppet("resource file \"#{client_datadir}\" ensure=absent force=true"))
-             end
-          end
-        end
-
       end
     end
   end


### PR DESCRIPTION
Reverts puppetlabs/beaker-pe#86

This PR is causing PEZ to fail. The issue is with the new code that attempts to run puppet on compile masters to fetch pe_repo. This will not work as puppet is not installed on compile masters at this point.


@shaigy Can you schedule a meeting with me when you are back from PTO to discuss what you want to achieve and we can see if theres a way to achieve it. 

The reason you were not seeing this in your testing is I believe since you didn't run with agents other than your master platform, just like PE acceptance tests jobs don't, so it skips the code since it already has the master platforms it will need:

see this test here:
https://cinext-jenkinsmaster-enterprise-prod-1.delivery.puppetlabs.net/view/pe-integration/view/pe-2018.1.x/job/enterprise_pe-acceptance-tests_integration-system_pe_lei-mono_nightly_2018.1.x/44/LAYOUT=centos6-64mcd-64compile_master.fa-64hub.fa-64spoke.fa-64fa,LEGACY_AGENT_VERSION=NONE,PLATFORM=NONE,SCM_BRANCH=2018.1.x,UPGRADE_FROM=NONE,UPGRADE_TO_VERSION=NONE,label=beaker/consoleText

all centos 6 boxes, and so in the output you see this:

```
  Documentation: https://docs.puppet.com/pe/2018.1/index.html
          Release notes: https://docs.puppet.com/pe/2018.1/release_notes.html

          If this is a monolithic configuration, run 'puppet agent -t' to complete the setup of this system.

          If this is a split configuration, install or upgrade the remaining PE components, and then run puppet agent -t on the Puppet master, PuppetDB, and PE console, in that order.
          /tmp/2017-11-23_04.52.49.PVIWBX/puppet-enterprise-2018.1.0-rc4-15-g7043f3f-el-6-x86_64
        
        wxfbx8kttowejgl.delivery.puppetlabs.net (centos6-64-1) executed in 364.03 seconds
      
      * Setup frictionless installer on the master
      
      * Install agents
```

Notice how nothing is done in the `setup frictionless installer on master` block.

When you go to PEZ, https://cinext-jenkinsmaster-enterprise-prod-1.delivery.puppetlabs.net/job/enterprise_pez_integration-system-pezv2_smoke_2018.1.x/LAYOUT=sles12-64mcd-64compile_master.fa-osx1012-64f,LEGACY_AGENT_VERSION=NONE,UPGRADE_FROM=NONE,label=beaker/145/consoleText

it has sles and osx agents, so you see:

```
Documentation: https://docs.puppet.com/pe/2018.1/index.html
      Release notes: https://docs.puppet.com/pe/2018.1/release_notes.html

      If this is a monolithic configuration, run 'puppet agent -t' to complete the setup of this system.

      If this is a split configuration, install or upgrade the remaining PE components, and then run puppet agent -t on the Puppet master, PuppetDB, and PE console, in that order.
      /tmp/2017-11-23_06.06.58.16Zeo6/puppet-enterprise-2018.1.0-rc4-16-gf4b6c07-PEZ_cinext-jenkinsmaster-enterprise-prod-1-sles-12-x86_64
    
    v9kpr437nmilovp.delivery.puppetlabs.net (sles12-64-1) executed in 305.90 seconds
  
  * Setup frictionless installer on the master
    
    * accessing console dispatcher
```

Where it goes to add OSX pe_repo class and run puppet, which will then promptly fail because puppet is not yet installed on anything but the master