### PR TITLE
(PE-22724) Add logic to determine installer type for postgres upgrades

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -524,7 +524,7 @@ module Beaker
           # Do a generic install if this is masterless, not all the same PE version, an upgrade, or earlier than 2016.4
           return :generic if opts[:masterless]
           return :generic if hosts.map {|host| host['pe_ver']}.uniq.length > 1
-          return :generic if opts[:type] == :upgrade
+          return :generic if (opts[:type] == :upgrade) && (hosts.none? {|host| host['roles'].include?('pe_postgres')})
           return :generic if version_is_less(opts[:pe_ver] || hosts.first['pe_ver'], '2016.4')
           #PE-20610 Do a generic install for old versions on windows that needs msi install because of PE-18351
           return :generic if hosts.any? {|host| host['platform'] =~ /windows/ && install_via_msi?(host)}

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1102,6 +1102,11 @@ describe ClassMixedWithDSLInstallUtils do
       expect(subject.determine_install_type(hosts, {:type => :upgrade})).to eq(:generic)
     end
 
+    it 'identifies an upgrade with postgres as pe_managed_postgres' do
+      hosts = [master, puppetdb, console, pe_postgres]
+      expect(subject.determine_install_type(hosts, {:type => :upgrade})).to eq(:pe_managed_postgres)
+    end
+
     it 'identifies a legacy PE version as generic' do
       old_monolithic = make_host('monolithic', :pe_ver => '3.8', :roles => [ 'master', 'database', 'dashboard' ])
       old_agent = make_host('agent', :pe_ver => '3.8', :roles => ['frictionless'])


### PR DESCRIPTION
Previously if there was an upgrade occurring we'd just consider the install type as just generic.
With the addition of external postgres support to beaker-pe, that needs to be handled in its own method. So this PR adds in additional logic for checking for upgrade if there is a node with the pe_postgres role.
