### PR TITLE
(PE-22724) Fix up the pe_postgres error handling

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1342,8 +1342,10 @@ module Beaker
               begin
                 execute_installer_cmd(master, opts)
               rescue Beaker::Host::CommandFailure => e
-                #The way the master fails to install includes this specific line as of PE 2018.1.x.
-                unless e.message =~ /The operation could not be completed because RBACs database has not been initialized/
+                installer_log_dir = '/var/log/puppetlabs/installer'
+                latest_installer_log_file = on(master, "ls -1t #{installer_log_dir} | head -n1").stdout.chomp
+                #Check the lastest install log to confirm the expected failure is there
+                unless on(master, "grep 'The operation could not be completed because RBACs database has not been initialized' #{installer_log_dir}/#{latest_installer_log_file}")
                   raise "Install on master failed in an unexpected manner"
                 end
               end


### PR DESCRIPTION
Previously we were just looking at the error message. This error message
only contained the last 10 lines. In PE 2016.4.x that is enough to ensure
what went wrong. But there was more error handling added after, and so the
message we are attempting to read is higher up and not captured by the error
message.
This PR adds in looking at the lastest install log on the master and grepping
it for the expected error message.
