### PR TITLE
(maint) Add beaker-abs to gemspec

### DIFF
--- a/beaker-pe.gemspec
+++ b/beaker-pe.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   # Run time dependencies
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
   s.add_runtime_dependency 'beaker-answers', '~> 0.0'
+  s.add_runtime_dependency 'beaker-abs'
 
 end
 


### PR DESCRIPTION
This is needed in order to migrate beaker jobs over to jenkins-sre.
While PR testing will continue to use vmpooler, nightlies will use abs.