### PR TITLE
PE-11351 clear puppet jenkins slaves

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -597,7 +597,8 @@ module Beaker
             on master, "echo \"#{@osmirror_host_ip}    #{@osmirror_host}\" >> /etc/hosts"
             on master, "echo \"#{@delivery_host_ip}    #{@delivery_host}\" >> /etc/hosts"
             on master, "iptables -A OUTPUT -p tcp -d #{master.connection.vmhostname} -j ACCEPT"
-            # internal puppet lan
+            # the next two lines clear the internal puppet lan
+            on master, "iptables -A OUTPUT -p tcp -d 10.16.0.0/16 -j ACCEPT"
             on master, "iptables -A OUTPUT -p tcp -d 10.32.0.0/16 -j ACCEPT"
             on master, "iptables -A OUTPUT -p tcp --dport 3128 -d #{@proxy_hostname} -j ACCEPT"
             on master, "iptables -A OUTPUT -p tcp -d #{@osmirror_host_ip} -j DROP"


### PR DESCRIPTION
In a previous commit, internal Puppet
addresses were cleared during proxy testing
for development purposes. Actual acceptance
tests are executed by jenkins hosts located
on a separate internal network.

This commit clears that additional network.

Please delete any headings that don't apply to this Pull Request (PR).

#### What's this PR do?
#### Who would you like to review this PR?

@puppetlabs/integration, @puppetlabs/beaker (repo owners)

#### Should any of this be tested outside the normal PR CI cycle?
#### Any background context you want to provide?
#### Questions for reviewers?
