### PR TITLE
PE-23463 Stop agent on master in mono install

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -569,12 +569,15 @@ module Beaker
             on master, installer_cmd(master, opts)
           end
 
-          install_agents_only_on(agents, opts)
+          step "Stop agent on master" do
+            stop_agent_on(master)
+          end
 
           step "Run puppet to setup mcollective and pxp-agent" do
             on(master, puppet_agent('-t'), :acceptable_exit_codes => [0,2])
-            run_puppet_on_non_infrastructure_nodes(all_hosts)
           end
+
+          install_agents_only_on(agents, opts)
 
           step "Run puppet a second time on the primary to populate services.conf (PE-19054)" do
             on(master, puppet_agent('-t'), :acceptable_exit_codes => [0,2])


### PR DESCRIPTION
With changes to PE-22051, we are not stopping puppet on master node
after install.This was causing some transient failures in CI
With this change, after installing PE on master, will wait for the
puppet run to stop. Also removed the extra agent run on agent nodes
since we are already running puppet on all of the agent nodes in
install_agents_only_on() method

