### PR TITLE
(maint) Pass all_hosts in simple_monolithic_install

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -564,7 +564,7 @@ module Beaker
           prepare_hosts(all_hosts, opts)
           fetch_pe([master], opts)
           prepare_host_installer_options(master)
-          generate_installer_conf_file_for(master, [master], opts)
+          generate_installer_conf_file_for(master, all_hosts, opts)
           step "Install PE on master" do
             on master, installer_cmd(master, opts)
           end

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -10,7 +10,7 @@ class ClassMixedWithDSLInstallUtils
   include Beaker::DSL::Patterns
   include Beaker::DSL::PE
 
-  attr_accessor :hosts, :metadata, :options
+  attr_accessor :hosts, :metadata, :options, :logger
 
   def initialize
     @metadata = {}
@@ -21,10 +21,6 @@ class ClassMixedWithDSLInstallUtils
   # mock out `metadata` that is initialized in a test case.
   def metadata
     @metadata ||= {}
-  end
-
-  def logger
-    @logger ||= RSpec::Mocks::Double.new('logger').as_null_object
   end
 end
 
@@ -70,6 +66,16 @@ describe ClassMixedWithDSLInstallUtils do
                         lei_hosts[3][:roles] = ['frictionless', 'lb_connect']
                         lei_hosts[3][:working_dir] = '/tmp'
                         lei_hosts }
+
+  let(:logger) do
+    logger = double('logger').as_null_object
+    allow(logger).to receive(:with_indent).and_yield
+    logger
+  end
+
+  before(:each) do
+    subject.logger = logger
+  end
 
   context '#prep_host_for_upgrade' do
 


### PR DESCRIPTION
Two maint patches.

    (maint) Update logger double for specs to handle with_indent ￼…
puppetlabs/beaker#4ab9f46 fixed up logging indentation by adding a
with_indent method that decorates identation handling and yields.
The beaker-pe specs mock a lot of Beaker internals to validate that some
expected set of commandline actions occur. With the change to Beaker
logger, the specs logger double needed to handle with_indent and yield
as well.


    (maint) Provide all hosts for pe.conf generation ￼…
...in simple_monolithic_install(). Passing just the [master] array does
not allow beaker-answers to set up an agent_platforms array with all
agent platform classes. Currently this only affects installs with the
pe-modules-next feature flag.

@puppetlabs/integration 