### PR TITLE
(PE-20250) Add in support for the puppet service debug flag

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -148,6 +148,13 @@ module Beaker
             end
           end
 
+          # pe_repo also supports flags that will determine what happens during the frictionless install
+          # Current support in beaker-pe is for:
+          # --puppet-service-debug, when running puppet service enable, the debug flag is passed into puppt service
+          if host[:puppet_service_debug_flag] == true
+            frictionless_install_opts << '--puppet-service-debug'
+          end
+
           # If this is an agent node configured to connect to the loadbalancer
           # using 'lb_connect' role, then use loadbalancer in the download url
           # instead of master

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -314,6 +314,18 @@ describe ClassMixedWithDSLInstallUtils do
 
       expect( subject.frictionless_agent_installer_cmd( lb_test_hosts[3], {}, '2016.4.0' ) ).to eq(expecting)
     end
+
+    it 'generates a unix PE frictionless install command with the puppet service debug flag' do
+      host[:puppet_service_debug_flag] = true
+      expecting = [
+        "FRICTIONLESS_TRACE='true'",
+        "export FRICTIONLESS_TRACE",
+        "cd /tmp && curl --tlsv1 -O -k https://testmaster:8140/packages/current/install.bash && bash install.bash --puppet-service-debug"
+      ].join("; ")
+
+      expect( subject.frictionless_agent_installer_cmd( host, {}, '2016.4.0' ) ).to eq(expecting)
+    end
+
   end
 
   describe 'install_ca_cert_on' do


### PR DESCRIPTION
When frictionlessly installing, if we want to have the puppet service
command run with the debug option we need to pass in a flag.
This PR checks for a host with the option set puppet_service_debug_flag.
If it find that it adds to the frictionless options --puppet-service-debug.
Which pe-repo will then use to turn on debugging for the puppet service command.
