### PR TITLE
(PE-20250) Add version checking for the puppet service debug flag

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -148,10 +148,10 @@ module Beaker
             end
           end
 
-          # pe_repo also supports flags that will determine what happens during the frictionless install
+          # PE 2018.1.0 introduced a pe_repo flag that will determine what happens during the frictionless install
           # Current support in beaker-pe is for:
           # --puppet-service-debug, when running puppet service enable, the debug flag is passed into puppt service
-          if host[:puppet_service_debug_flag] == true
+          if (host[:puppet_service_debug_flag] == true and ! version_is_less(pe_version, '2018.1.0'))
             frictionless_install_opts << '--puppet-service-debug'
           end
 

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -315,7 +315,18 @@ describe ClassMixedWithDSLInstallUtils do
       expect( subject.frictionless_agent_installer_cmd( lb_test_hosts[3], {}, '2016.4.0' ) ).to eq(expecting)
     end
 
-    it 'generates a unix PE frictionless install command with the puppet service debug flag' do
+    it 'generates a unix PE frictionless install command without the puppet service debug flag if installing on an older version of PE' do
+      host[:puppet_service_debug_flag] = true
+      expecting = [
+        "FRICTIONLESS_TRACE='true'",
+        "export FRICTIONLESS_TRACE",
+        "cd /tmp && curl --tlsv1 -O -k https://testmaster:8140/packages/current/install.bash && bash install.bash"
+      ].join("; ")
+
+      expect( subject.frictionless_agent_installer_cmd( host, {}, '2016.4.0' ) ).to eq(expecting)
+    end
+
+    it 'generates a unix PE frictionless install command with the puppet service debug flag if installing 2018.1.0' do
       host[:puppet_service_debug_flag] = true
       expecting = [
         "FRICTIONLESS_TRACE='true'",
@@ -323,9 +334,8 @@ describe ClassMixedWithDSLInstallUtils do
         "cd /tmp && curl --tlsv1 -O -k https://testmaster:8140/packages/current/install.bash && bash install.bash --puppet-service-debug"
       ].join("; ")
 
-      expect( subject.frictionless_agent_installer_cmd( host, {}, '2016.4.0' ) ).to eq(expecting)
+      expect( subject.frictionless_agent_installer_cmd( host, {}, '2018.1.0' ) ).to eq(expecting)
     end
-
   end
 
   describe 'install_ca_cert_on' do


### PR DESCRIPTION
Previously if we wanted to debug a frictionless install we would
check to see if flag was passed to beaker-pe and then set the flag
on the frictionless install line.
In the case of an upgrade, this caused problem since PE 2016.4.10's
frictionless install would error out if it saw the debug flag passed in.
This PR adds in logic to checking the debug flag to also consider what version
of PE.