### PR TITLE
(maint) Fix up error handling logic

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1427,7 +1427,7 @@ module Beaker
                 installer_log_dir = '/var/log/puppetlabs/installer'
                 latest_installer_log_file = on(master, "ls -1t #{installer_log_dir} | head -n1").stdout.chomp
                 #Check the lastest install log to confirm the expected failure is there
-                unless on(master, "grep 'The operation could not be completed because RBACs database has not been initialized' #{installer_log_dir}/#{latest_installer_log_file}")
+                unless on(master, "grep 'The operation could not be completed because RBACs database has not been initialized' #{installer_log_dir}/#{latest_installer_log_file}", :acceptable_exit_codes => [0,1]).exit_code == 0
                   raise "Install on master failed in an unexpected manner"
                 end
               end

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1213,8 +1213,10 @@ describe ClassMixedWithDSLInstallUtils do
       #Error handling
       @installer_log_file_name = Beaker::Result.new( {}, '' )
       @installer_log_file_name.stdout = "installer_log_name"
+      exit_code_mock = Object.new
+      allow(exit_code_mock).to receive(:exit_code).and_return( 0 )
       allow(subject).to receive(:on).with(mono_master, "ls -1t /var/log/puppetlabs/installer | head -n1").and_return(@installer_log_file_name)
-      allow(subject).to receive(:on).with(mono_master, "grep 'The operation could not be completed because RBACs database has not been initialized' /var/log/puppetlabs/installer/installer_log_name").and_return(true)
+      allow(subject).to receive(:on).with(mono_master, "grep 'The operation could not be completed because RBACs database has not been initialized' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(exit_code_mock)
 
       allow(subject).to receive(:execute_installer_cmd).with(pe_postgres, {}).once
       expect(subject).to receive(:execute_installer_cmd).with(mono_master, {}).once.ordered
@@ -1243,8 +1245,10 @@ describe ClassMixedWithDSLInstallUtils do
       #Error handling
       @installer_log_file_name = Beaker::Result.new( {}, '' )
       @installer_log_file_name.stdout = "installer_log_name"
+      exit_code_mock = Object.new
+      allow(exit_code_mock).to receive(:exit_code).and_return(1)
       allow(subject).to receive(:on).with(mono_master, "ls -1t /var/log/puppetlabs/installer | head -n1").and_return(@installer_log_file_name)
-      allow(subject).to receive(:on).with(mono_master, "grep 'The operation could not be completed because RBACs database has not been initialized' /var/log/puppetlabs/installer/installer_log_name").and_return(false)
+      allow(subject).to receive(:on).with(mono_master, "grep 'The operation could not be completed because RBACs database has not been initialized' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(exit_code_mock)
 
       expect{ subject.do_install_pe_with_pe_managed_external_postgres([mono_master, pe_postgres, agent], {}) }.to raise_error(RuntimeError, "Install on master failed in an unexpected manner")
     end


### PR DESCRIPTION
Previously we grepped the install log when the external postgres job
failed to install on the master. We were looking for a specific error
message that is expected.
If that message isn't in the log, we want to fail with an error message
that makes sense. However, if the grep failed Beaker would exit there
and it left a confusing error message.