### PR TITLE
RFC (PE-22681) Special case the redhat-fips platform classification

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -409,7 +409,14 @@ module Beaker
               klass = "pe_repo::platform::windows_x86_64"
             end
           else
-            klass = "pe_repo::platform::#{klass}"
+            # Redhat FIPS is an awkward special case we need to check for
+            # where the platform is el-7 but the packaging_platform is
+            # redhat-fips-7:
+            if host['packaging_platform'] == "redhat-fips-7-x86_64"
+              klass = "pe_repo::platform::redhatfips_7_x86_64"
+            else
+              klass = "pe_repo::platform::#{klass}"
+            end
           end
           if version_is_less(host['pe_ver'], '3.8')
             # use the old rake tasks


### PR DESCRIPTION
This is a workaround for the fact that RedHat FIPS platforms are defined
by beaker-hostgenerator to use a platform of el-7-x86_64, but also have
packaging_platform defined as redhat-fips-7-x86_64.

@puppetlabs/integration, @puppetlabs/beaker (repo owners)

Some background on the BHG platform naming can be found in:

https://github.com/puppetlabs/beaker-hostgenerator/pull/107

I'm not sure how best to test this.