### PR TITLE
(PE-23950) Modify meep flags

### DIFF
--- a/lib/beaker-pe/install/feature_flags.rb
+++ b/lib/beaker-pe/install/feature_flags.rb
@@ -20,7 +20,7 @@ module Beaker::DSL::InstallUtils
   #     }
   #   }
   #
-  # All flag keys are expected to be downcased with hyphens.
+  # All flag keys are expected to be downcased with underscores.
   #
   # Environment variables may be uppercased.
   class FeatureFlags

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -608,6 +608,7 @@ module Beaker
           prepare_hosts(all_hosts, opts)
           fetch_pe([master], opts)
           prepare_host_installer_options(master)
+          register_feature_flags!(opts)
           generate_installer_conf_file_for(master, all_hosts, opts)
           step "Install PE on master" do
             on master, installer_cmd(master, opts)

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -689,6 +689,14 @@ describe ClassMixedWithDSLInstallUtils do
     include_examples('test flag', 'meep_classification')
   end
 
+  describe 'manage_puppet_service?' do
+    let(:old_behavior_version) { '2017.3.0' }
+    let(:threshold_version) { '2018.1.0' }
+    let(:method) { 'manage_puppet_service?' }
+
+    include_examples('test flag', 'pe_modules_next')
+  end
+
   describe 'generate_installer_conf_file_for' do
     let(:master) { hosts.first }
 
@@ -2309,7 +2317,7 @@ describe ClassMixedWithDSLInstallUtils do
   end
 
   describe 'configure_puppet_agent_service' do
-    let(:pe_version) { '2017.1.0' }
+    let(:pe_version) { '2018.1.0' }
     let(:master) { hosts[0] }
 
     before(:each) do
@@ -2321,17 +2329,17 @@ describe ClassMixedWithDSLInstallUtils do
       expect { subject.configure_puppet_agent_service }.to raise_error(ArgumentError, /wrong number/)
     end
 
-    context 'master prior to 2017.1.0' do
+    context 'master prior to 2018.1.0' do
       let(:pe_version) { '2016.5.1' }
 
       it 'raises an exception about version' do
         expect { subject.configure_puppet_agent_service({}) }.to(
-          raise_error(StandardError, /Can only manage.*2017.1.0; tried.* 2016.5.1/)
+          raise_error(StandardError, /Can only manage.*2018.1.0; tried.* 2016.5.1/)
         )
       end
     end
 
-    context '2017.1.0 master' do
+    context '2018.1.0 master' do
       let(:pe_conf_path) { '/etc/puppetlabs/enterprise/conf.d/pe.conf' }
       let(:pe_conf) do
         <<-EOF
@@ -2345,18 +2353,13 @@ describe ClassMixedWithDSLInstallUtils do
 "node_roles": {
   "pe_role::monolithic::primary_master": ["#{master.name}"],
 }
-"pe_infrastructure::agent::puppet_service_managed": true
-"pe_infrastructure::agent::puppet_service_ensure": "stopped"
-"pe_infrastructure::agent::puppet_service_enabled": false
+"puppet_enterprise::profile::agent::puppet_service_managed": true
+"puppet_enterprise::profile::agent::puppet_service_ensure": "stopped"
+"puppet_enterprise::profile::agent::puppet_service_enabled": false
         EOF
       end
 
       it "modifies the agent puppet service settings in pe.conf" do
-        # mock hitting the console
-        dispatcher = double('dispatcher').as_null_object
-        expect(subject).to receive(:get_console_dispatcher_for_beaker_pe)
-          .and_return(dispatcher)
-
         assert_meep_conf_edit(pe_conf, gold_pe_conf, pe_conf_path) do
           subject.configure_puppet_agent_service(:ensure => 'stopped', :enabled => false)
         end


### PR DESCRIPTION
    (PE-23950) Add meep_classification flag ￼…
Previously PE test workflows which varied based on which pe-modules code branch
(current or next) was installed relied on testing the general
pe-modules-next flag. Either you had/were going to install pe-modules,
or pe-modules-next and all other behavior stemmed from that.

Given that we're working to merge next into irving, but retain irving's
node groups for compatability, we need more discrete feature flags for
classification.  The meep_classification flag, if true, now guards
future behavior when MEEP manages classification. It defaults to false.

A meep_schema_version is always passed to beaker-answers if we are using
meep so that beaker-answers will not attempt to squash structured data
(like the feature_flags hash) into single key value pairs.

    (PE-23950) Add a manage_puppet_service flag ￼…
So that we can continue to manage the puppet agent service per PE-11353
after the next branches are merged into irving. Temporarily this
behavior is still gated by the pe-modules-next flag.

Since pe.conf is now part of the default hiera hierarchy for
puppet_enterprise, we don't need to touch the agent node group.

---

Marking this do not merge until we've had more time to test installs with and without the pe-modules-next flag.