### PR TITLE
(PE-22681) Use packaging_platform instead of platform when set

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -394,7 +394,9 @@ module Beaker
         def deploy_frictionless_to_master(host)
           return if use_meep_for_classification?(master[:pe_ver], options)
 
-          platform = host['platform']
+          # For some platforms (e.g, redhatfips), packaging_platfrom is set and should
+          # be used as the primary source of truth for the platform string.
+          platform = host['packaging_platform'] || host['platform']
 
           # We don't have a separate AIX 7.2 build, so it is
           # classified as 7.1 for pe_repo purposes


### PR DESCRIPTION
packaging_platform can be used in beaker-puppet to specify the platform
a pacakge was built on, and when specified in a beaker config should be
the primary source of truth for the platform string. This is the case
for platforms such as redhatfips, which are otherwise treated as an el
platform in beaker.