### PR TITLE
(maint) Add a sync_pe_conf file helper

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1638,6 +1638,20 @@ module Beaker
           end
         end
 
+        # Sync pe.conf from the master to another infrastructure node.
+        # Useful when updating pe.conf to reconfigure infrastructure, where
+        # you first update_pe_conf then sync_pe_conf to infrastructure hosts.
+        #
+        # @param [Host] host The host to sync to
+        # @param pe_conf_file [String] The file to sync
+        #   (/etc/puppetlabs/enterprise/conf.d/pe.conf by default)
+        def sync_pe_conf(host, pe_conf_file = PE_CONF_FILE)
+          Dir.mktmpdir('sync_pe_conf') do |tmpdir|
+            scp_from(master, pe_conf_file, tmpdir)
+            scp_to(host, File.join(tmpdir, File.basename(pe_conf_file)), pe_conf_file)
+          end
+        end
+
         # If the key is unquoted and does not contain pathing ('.'),
         # quote to ensure that puppet namespaces are protected
         #

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -2394,6 +2394,20 @@ describe ClassMixedWithDSLInstallUtils do
     end
   end
 
+  describe 'sync_pe_conf' do
+    let(:pe_conf_path) { '/etc/puppetlabs/enterprise/conf.d/pe.conf' }
+
+    before(:each) do
+      allow( subject ).to receive( :master ).and_return( 'testmaster' )
+    end
+
+    it "copies pe.conf from master to a host" do
+      expect(subject).to receive(:scp_from).with('testmaster', pe_conf_path, %r{sync_pe_conf})
+      expect(subject).to receive(:scp_to).with('host', %r{sync_pe_conf.*/pe\.conf}, pe_conf_path)
+      subject.sync_pe_conf('host')
+    end
+  end
+
   describe 'create_or_update_node_conf' do
     let(:pe_version) { '2017.1.0' }
     let(:master) { hosts[0] }


### PR DESCRIPTION
#### What's this PR do?

This supports a workflow of updating pe.conf on the master, then syncing
it to other infrastructure nodes where configuration needs to be
updated.

#### Who would you like to review this PR?

@puppetlabs/integration, @puppetlabs/beaker (repo owners)

#### Should any of this be tested outside the normal PR CI cycle?

New feature, so probably not necessary.