### PR TITLE
(maint) Enable MCO if hub/spoke roles are in use

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ if ENV['GEM_SOURCE'] =~ /artifactory\.delivery\.puppetlabs\.net/
   gem "scooter", *location_for(ENV['SCOOTER_VERSION'] || '~> 3.0')
 end
 
+gem 'deep_merge'
+
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
 end

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -5,6 +5,7 @@ require 'beaker-pe/install/feature_flags'
 require "beaker-answers"
 require "timeout"
 require "json"
+require "deep_merge"
 module Beaker
   module DSL
     module InstallUtils
@@ -1074,6 +1075,16 @@ module Beaker
           Beaker::DSL::InstallUtils::FeatureFlags.new(opts).register_flags!
         end
 
+        # PE 2018.1.0 has mco disabled by default. If we are running hosts with
+        # roles hub or spoke then we intend to test mco. In this case we need
+        # to change a setting in pe.conf to allow mco to be enabled.
+        def get_mco_setting(hosts)
+          if(version_is_less('2018.1', hosts[0]['pe_ver']) && (hosts.any? {|h| h['roles'].include?('hub') || h['roles'].include?('spoke')}))
+            return {:answers => { 'pe_install::disable_mco' => false }}
+          end
+          return {}
+        end
+
         # Generates a Beaker Answers object for the passed *host* and creates
         # the answer or pe.conf configuration file on the *host* needed for
         # installation.
@@ -1087,6 +1098,9 @@ module Beaker
         # @param [Hash] opts The Beaker options hash
         # @return [BeakerAnswers::Answers] the generated answers object
         def generate_installer_conf_file_for(host, hosts, opts)
+          possible_mco_enabled_setting = get_mco_setting(hosts)
+          opts ||= {}
+          opts = possible_mco_enabled_setting.deep_merge(opts)
           beaker_answers_opts = setup_beaker_answers_opts(host, opts)
           answers = BeakerAnswers::Answers.create(
             opts[:pe_ver] || host['pe_ver'], hosts, beaker_answers_opts

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -691,6 +691,7 @@ describe ClassMixedWithDSLInstallUtils do
         '/tmp/answers',
         %r{q_install=y.*q_puppetmaster_certname=#{master}}m
       )
+      expect(subject).to receive(:get_mco_setting).and_return({})
       subject.generate_installer_conf_file_for(master, hosts, opts)
     end
 
@@ -702,6 +703,7 @@ describe ClassMixedWithDSLInstallUtils do
         '/tmp/pe.conf',
         %r{\{.*"puppet_enterprise::puppet_master_host": "#{master.hostname}"}m
       )
+      expect(subject).to receive(:get_mco_setting).and_return({})
       subject.generate_installer_conf_file_for(master, hosts, opts)
     end
   end
@@ -1389,6 +1391,33 @@ describe ClassMixedWithDSLInstallUtils do
     end
   end
 
+  describe 'get_mco_setting' do
+    let(:master) { make_host('master', :pe_ver => '2018.1.0', :platform => 'ubuntu-16.04-x86_64', :roles => ['master', 'database', 'dashboard']) }
+    let(:hub) { make_host('agent', :pe_ver => '2018.1', :platform => 'el-7-x86_64', :roles => ['frictionless', 'hub', 'agent']) }
+    let(:spoke) { make_host('agent', :pe_ver => '2018.1', :roles => ['frictionless', 'spoke', 'agent']) }
+
+    it 'returns mco enabled with both hub and spoke and version is greater' do
+      hosts = [master, hub, spoke]
+      allow(subject).to receive(:version_is_less).and_return(true)
+      expect(subject.get_mco_setting(hosts)).to eq({:answers => {'pe_install::disable_mco' => false}})
+    end
+    it 'returns mco enabled with just hub and version is greater' do
+      hosts = [master, hub]
+      allow(subject).to receive(:version_is_less).and_return(true)
+      expect(subject.get_mco_setting(hosts)).to eq({:answers => {'pe_install::disable_mco' => false}})
+    end
+    it 'returns mco enabled with just spoke and version is greater' do
+      hosts = [master, spoke]
+      allow(subject).to receive(:version_is_less).and_return(true)
+      expect(subject.get_mco_setting(hosts)).to eq({:answers => {'pe_install::disable_mco' => false}})
+    end
+    it 'does not return anything if the version is less' do
+      hosts = [master, hub, spoke]
+      allow(subject).to receive(:version_is_less).and_return(false)
+      expect(subject.get_mco_setting(hosts)).to eq({})
+    end
+  end
+
   describe '#deploy_frictionless_to_master' do
     let(:master) { make_host('master', :pe_ver => '2017.2', :platform => 'ubuntu-16.04-x86_64', :roles => ['master', 'database', 'dashboard']) }
     let(:agent) { make_host('agent', :pe_ver => '2017.2', :platform => 'el-7-x86_64', :roles => ['frictionless']) }
@@ -1432,6 +1461,7 @@ describe ClassMixedWithDSLInstallUtils do
     end
 
     it 'can perform a simple installation' do
+      expect(subject).to receive(:get_mco_setting).and_return({})
       allow( subject ).to receive( :verify_network_resources).with(hosts, nil)
       allow( subject ).to receive( :on ).and_return( Beaker::Result.new( {}, '' ) )
       allow( subject ).to receive( :fetch_pe ).and_return( true )
@@ -1504,6 +1534,7 @@ describe ClassMixedWithDSLInstallUtils do
         :roles => ['agent']
       }, 1)
       opts[:masterless] = true
+      expect(subject).to receive(:get_mco_setting).and_return({})
 
       allow( subject ).to receive( :verify_network_resources).with(hosts, nil)
       allow( subject ).to receive( :hosts ).and_return( hosts )
@@ -1691,6 +1722,7 @@ describe ClassMixedWithDSLInstallUtils do
       hosts[0][:roles] = ['master', 'database', 'dashboard']
       hosts[1][:platform] = Beaker::Platform.new('el-6-x86_64')
       opts[:HOSTS] = {}
+      expect(subject).to receive(:get_mco_setting).and_return({})
       hosts.each do |host|
         opts[:HOSTS][host.name] = host
       end


### PR DESCRIPTION
In PE Irving MCO is disabled by default. This currently breaks our LEI
testing. This PR will make it so MCO is enabled if there are any roles
that are hub or spoke if the version of PE being installed is PE Irving
or newer.
