### PR TITLE
PE-24016 Update escaped errors with external postgres install

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1501,7 +1501,9 @@ module Beaker
           latest_installer_log_file = on(host, "ls -1t #{installer_log_dir} | head -n1").stdout.chomp
           # As of PE Irving (PE 2018.1.x), these are the only two expected errors
           allowed_errors = ["The operation could not be completed because RBACs database has not been initialized",
-            "Timeout waiting for the database pool to become ready"]
+            "Timeout waiting for the database pool to become ready",
+            "Systemd restart for pe-console-services failed",
+            "Reloading pe-console-services: Reload timed out after 120 seconds"]
 
           allowed_errors.each do |error|
             if(on(host, "grep '#{error}' #{installer_log_dir}/#{latest_installer_log_file}", :acceptable_exit_codes => [0,1]).exit_code == 0)

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1233,6 +1233,8 @@ describe ClassMixedWithDSLInstallUtils do
       allow(subject).to receive(:on).with(mono_master, "ls -1t /var/log/puppetlabs/installer | head -n1").and_return(@installer_log_file_name)
       allow(subject).to receive(:on).with(mono_master, "grep 'The operation could not be completed because RBACs database has not been initialized' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(zero_exit_code_mock)
       allow(subject).to receive(:on).with(mono_master, "grep 'Timeout waiting for the database pool to become ready' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+      allow(subject).to receive(:on).with(mono_master, "grep 'Systemd restart for pe-console-services failed' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+      allow(subject).to receive(:on).with(mono_master, "grep 'Reloading pe-console-services: Reload timed out after 120 seconds' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
       expect(subject.is_expected_pe_postgres_failure?(mono_master)). to eq(true)
     end
 
@@ -1246,6 +1248,38 @@ describe ClassMixedWithDSLInstallUtils do
       allow(subject).to receive(:on).with(mono_master, "ls -1t /var/log/puppetlabs/installer | head -n1").and_return(@installer_log_file_name)
       allow(subject).to receive(:on).with(mono_master, "grep 'The operation could not be completed because RBACs database has not been initialized' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
       allow(subject).to receive(:on).with(mono_master, "grep 'Timeout waiting for the database pool to become ready' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(zero_exit_code_mock)
+      allow(subject).to receive(:on).with(mono_master, "grep 'Systemd restart for pe-console-services failed' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+      allow(subject).to receive(:on).with(mono_master, "grep 'Reloading pe-console-services: Reload timed out after 120 seconds' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+      expect(subject.is_expected_pe_postgres_failure?(mono_master)). to eq(true)
+    end
+
+    it 'will return true if it is the systemd restart of cosnole-services failure matcher' do
+      @installer_log_file_name = Beaker::Result.new( {}, '' )
+      @installer_log_file_name.stdout = "installer_log_name"
+      zero_exit_code_mock = Object.new
+      allow(zero_exit_code_mock).to receive(:exit_code).and_return(0)
+      one_exit_code_mock = Object.new
+      allow(one_exit_code_mock).to receive(:exit_code).and_return(1)
+      allow(subject).to receive(:on).with(mono_master, "ls -1t /var/log/puppetlabs/installer | head -n1").and_return(@installer_log_file_name)
+      allow(subject).to receive(:on).with(mono_master, "grep 'The operation could not be completed because RBACs database has not been initialized' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+      allow(subject).to receive(:on).with(mono_master, "grep 'Timeout waiting for the database pool to become ready' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+      allow(subject).to receive(:on).with(mono_master, "grep 'Systemd restart for pe-console-services failed' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(zero_exit_code_mock)
+      allow(subject).to receive(:on).with(mono_master, "grep 'Reloading pe-console-services: Reload timed out after 120 seconds' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+      expect(subject.is_expected_pe_postgres_failure?(mono_master)). to eq(true)
+    end
+
+    it 'will return true if it is the console-services reload timeout string matcher' do
+      @installer_log_file_name = Beaker::Result.new( {}, '' )
+      @installer_log_file_name.stdout = "installer_log_name"
+      zero_exit_code_mock = Object.new
+      allow(zero_exit_code_mock).to receive(:exit_code).and_return(0)
+      one_exit_code_mock = Object.new
+      allow(one_exit_code_mock).to receive(:exit_code).and_return(1)
+      allow(subject).to receive(:on).with(mono_master, "ls -1t /var/log/puppetlabs/installer | head -n1").and_return(@installer_log_file_name)
+      allow(subject).to receive(:on).with(mono_master, "grep 'The operation could not be completed because RBACs database has not been initialized' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+      allow(subject).to receive(:on).with(mono_master, "grep 'Timeout waiting for the database pool to become ready' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+      allow(subject).to receive(:on).with(mono_master, "grep 'Systemd restart for pe-console-services failed' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+      allow(subject).to receive(:on).with(mono_master, "grep 'Reloading pe-console-services: Reload timed out after 120 seconds' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(zero_exit_code_mock)
       expect(subject.is_expected_pe_postgres_failure?(mono_master)). to eq(true)
     end
 
@@ -1257,6 +1291,8 @@ describe ClassMixedWithDSLInstallUtils do
       allow(subject).to receive(:on).with(mono_master, "ls -1t /var/log/puppetlabs/installer | head -n1").and_return(@installer_log_file_name)
       allow(subject).to receive(:on).with(mono_master, "grep 'The operation could not be completed because RBACs database has not been initialized' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
       allow(subject).to receive(:on).with(mono_master, "grep 'Timeout waiting for the database pool to become ready' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+      allow(subject).to receive(:on).with(mono_master, "grep 'Systemd restart for pe-console-services failed' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+      allow(subject).to receive(:on).with(mono_master, "grep 'Reloading pe-console-services: Reload timed out after 120 seconds' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
       expect(subject.is_expected_pe_postgres_failure?(mono_master)). to eq(false)
     end
   end


### PR DESCRIPTION
After increasing the rbac timeout, installation on the master is failing
at a different point now with pe-console services restart failure error.
This failure is expected. Added new error to the list of expected errors
to skip past this expected failure  point to continue with the installation
of postgres node.


