### PR TITLE
PE-24218 Fix version check

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1111,8 +1111,11 @@ module Beaker
         # roles hub or spoke then we intend to test mco. In this case we need
         # to change a setting in pe.conf to allow mco to be enabled.
         def get_mco_setting(hosts)
-          if(version_is_less('2018.1', hosts[0]['pe_ver']) && (hosts.any? {|h| h['roles'].include?('hub') || h['roles'].include?('spoke')}))
-            return {:answers => { 'pe_install::disable_mco' => false }}
+          pe_version = hosts[0]['pe_ver']
+          if (!version_is_less(pe_version, '2018.1') && version_is_less(pe_version, '2018.1.999'))
+                if (hosts.any? {|h| h['roles'].include?('hub') || h['roles'].include?('spoke')})
+                  return {:answers => { 'pe_install::disable_mco' => false }}
+                end
           end
           return {}
         end

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1490,22 +1490,29 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'returns mco enabled with both hub and spoke and version is greater' do
       hosts = [master, hub, spoke]
-      allow(subject).to receive(:version_is_less).and_return(true)
       expect(subject.get_mco_setting(hosts)).to eq({:answers => {'pe_install::disable_mco' => false}})
     end
     it 'returns mco enabled with just hub and version is greater' do
       hosts = [master, hub]
-      allow(subject).to receive(:version_is_less).and_return(true)
       expect(subject.get_mco_setting(hosts)).to eq({:answers => {'pe_install::disable_mco' => false}})
     end
     it 'returns mco enabled with just spoke and version is greater' do
       hosts = [master, spoke]
-      allow(subject).to receive(:version_is_less).and_return(true)
       expect(subject.get_mco_setting(hosts)).to eq({:answers => {'pe_install::disable_mco' => false}})
     end
-    it 'does not return anything if the version is less' do
+    it 'returns mco enabled for versions between 2018.1 and  2018.2' do
+      master['pe_ver'] = '2018.1.1'
       hosts = [master, hub, spoke]
-      allow(subject).to receive(:version_is_less).and_return(false)
+      expect(subject.get_mco_setting(hosts)).to eq({:answers => {'pe_install::disable_mco' => false}})
+    end
+    it 'does not return anything for versions >= 2018.2' do
+      master['pe_ver'] = '2018.2.0'
+      hosts = [master, hub, spoke]
+      expect(subject.get_mco_setting(hosts)).to eq({})
+    end
+    it 'does not return anything for versions <  2018.1' do
+      master['pe_ver'] = '2017.3.7'
+      hosts = [master, hub, spoke]
       expect(subject.get_mco_setting(hosts)).to eq({})
     end
   end


### PR DESCRIPTION
Fixed the version for enabling mco so that mco will be enabled for
versions between 2018.1.0(including) and 2018.2.0 in LEI. Current version check did not work for 2018.1.0

