### PR TITLE
(maint) Add a timeout to the network resource check

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -478,7 +478,7 @@ module Beaker
             if network_resources != nil
               network_resources.each do |resource|
                 # curl the network resource silently (-s), only connect (-I), and don't print the output
-                on host, "curl -I -s #{resource} > /dev/null", :accept_all_exit_codes => true
+                on host, "curl -I -s --max-time 10 #{resource} > /dev/null", :accept_all_exit_codes => true
                 if host.connection.logger.last_result.exit_code != 0
                   logger.warn("Connection error: #{host.host_hash[:vmhostname]} was unable to connect to #{resource}. Please ensure that your test does not require this resource.")
                 end


### PR DESCRIPTION
We run the network resource check for each node, for some of our more
complicated testing this can be anywhere from 5 nodes to 10 nodes.
If the curl command times out, this can cause the network resource check
to last for 10-15 minutes.
This PR puts a 10 second timeout on the curl command to try to reduce
the time the network resource check takes.

Please delete any headings that don't apply to this Pull Request (PR).

#### What's this PR do?
#### Who would you like to review this PR?

@puppetlabs/integration, @puppetlabs/beaker (repo owners)

#### Should any of this be tested outside the normal PR CI cycle?
#### Any background context you want to provide?
#### Questions for reviewers?
