### PR TITLE
BKR-1478 Remove client_datadir on Windows

### DIFF
--- a/beaker-pe.gemspec
+++ b/beaker-pe.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   # Testing dependencies
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its'
-  s.add_development_dependency 'fakefs', '~> 0.6'
+  s.add_development_dependency 'fakefs', '~> 0.6', '< 0.14.0'
   s.add_development_dependency 'rake', '~> 10.1'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'pry', '~> 0.10'

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -129,6 +129,13 @@ module Beaker
           downloadhost
         end
 
+        #Remove client_datadir on the host
+        #@param [Host] the host
+        def remove_client_datadir(host)
+          client_datadir = host.puppet['client_datadir']
+          on(host, "rm -rf #{client_datadir}")
+        end
+
         # Generate the command line string needed to from a frictionless puppet-agent
         # install on this host in a PE environment.
         #
@@ -807,8 +814,7 @@ module Beaker
                 end
                 #Workaround for windows frictionless install, see BKR-943 for the reason
                 if (host['platform'] =~ /windows/) and (host['roles'].include? 'frictionless')
-                  client_datadir = host.puppet['client_datadir']
-                  on(host , puppet("resource file \"#{client_datadir}\" ensure=absent force=true"))
+                  remove_client_datadir(host)
                 end
               end
             end
@@ -1841,8 +1847,7 @@ module Beaker
 
              #Workaround for windows frictionless install, see BKR-943
              agent_nodes.select {|agent| agent['platform'] =~ /windows/}.each do |agent|
-               client_datadir = agent.puppet['client_datadir']
-               on(agent, puppet("resource file \"#{client_datadir}\" ensure=absent force=true"))
+               remove_client_datadir(agent)
              end
           end
         end


### PR DESCRIPTION
Deelete the 'client_datadir' using 'rm -rf' instead of using puppet file
resource 'ensure=absent' method to avoid creating backup files
Also, added version dependency for 'fakefs' gem to resolve error when using
ruby-2.2.5

