### PR TITLE
PE-23297 Install agents using puppetlabs-bootstrap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ if ENV['GEM_SOURCE'] =~ /artifactory\.delivery\.puppetlabs\.net/
   gem "scooter", *location_for(ENV['SCOOTER_VERSION'] || '~> 3.0')
 end
 
+#gem "beaker-task_helper", :git => "git@github.com:puppetlabs/beaker-task_helper.git"
 gem 'deep_merge'
 
 if File.exists? "#{__FILE__}.local"


### PR DESCRIPTION
This is just an initial attempt for doing frictionless agent installation using
puppetlabs-bootstrap module. This change will only work for linux. Some
more work is needed to be done for making it work on windows.

