### PR TITLE
(BKR-1492) Fix pe_defaults path

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1,4 +1,4 @@
-[ 'aio_defaults', 'pe_defaults', 'puppet_utils', 'windows_utils' ].each do |lib|
+[ 'aio_defaults', 'puppet_utils', 'windows_utils' ].each do |lib|
     require "beaker/dsl/install_utils/#{lib}"
 end
 require 'beaker-pe/install/feature_flags'


### PR DESCRIPTION
Missed a require in the original PR. Since this is required in beaker-pe.rb we don't need it here. Thanks @pinkypie.