### PR TITLE
(BKR-1509) beaker 4.0 upgrade process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,8 @@ def location_for(place, fake_version = nil)
   end
 end
 
-# We don't put beaker in as a test dependency because we
-# don't want to create a transitive dependency
 group :acceptance_testing do
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.0')
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4.0')
 end
 
 if ENV['GEM_SOURCE'] =~ /artifactory\.delivery\.puppetlabs\.net/

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ end
 
 group :acceptance_testing do
   gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4.0')
+  gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || '~> 1.3')
 end
 
 if ENV['GEM_SOURCE'] =~ /artifactory\.delivery\.puppetlabs\.net/

--- a/acceptance/pre_suite/install.rb
+++ b/acceptance/pre_suite/install.rb
@@ -1,1 +1,3 @@
+require 'test_helpers.rb'
+
 install_pe

--- a/acceptance/tests/first.rb
+++ b/acceptance/tests/first.rb
@@ -1,3 +1,4 @@
+require 'test_helpers.rb'
 
 # Acceptance level testing goes into files in the tests directory like this one,
 # Each file corresponding to a new test made up of individual testing steps

--- a/acceptance/tests/install_smoke_test.rb
+++ b/acceptance/tests/install_smoke_test.rb
@@ -1,3 +1,5 @@
+require 'test_helpers.rb'
+
 test_name "puppet install smoketest"
 
 step 'puppet install smoketest: verify \'facter --help\' can be successfully called on all hosts'

--- a/beaker-pe.gemspec
+++ b/beaker-pe.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'thin'
 
   # Run time dependencies
+  s.add_runtime_dependency 'beaker', '~>4.0'
   s.add_runtime_dependency 'beaker-puppet', '~>1.0'
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
   s.add_runtime_dependency 'beaker-answers', '~> 0.0'

--- a/beaker-pe.gemspec
+++ b/beaker-pe.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'thin'
 
   # Run time dependencies
-  s.add_runtime_dependency 'beaker-puppet'
+  s.add_runtime_dependency 'beaker-puppet', '~>1.0'
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
   s.add_runtime_dependency 'beaker-answers', '~> 0.0'
   s.add_runtime_dependency 'beaker-abs'

--- a/beaker-pe.gemspec
+++ b/beaker-pe.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'thin'
 
   # Run time dependencies
+  s.add_runtime_dependency 'beaker-puppet'
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
   s.add_runtime_dependency 'beaker-answers', '~> 0.0'
   s.add_runtime_dependency 'beaker-abs'

--- a/lib/beaker-pe.rb
+++ b/lib/beaker-pe.rb
@@ -1,3 +1,5 @@
+require 'beaker'
+
 require 'stringify-hash'
 require 'beaker-pe/version'
 require 'beaker-pe/install/pe_defaults'

--- a/lib/beaker-pe.rb
+++ b/lib/beaker-pe.rb
@@ -1,4 +1,5 @@
 require 'beaker'
+require 'beaker-puppet'
 
 require 'stringify-hash'
 require 'beaker-pe/version'

--- a/lib/beaker-pe.rb
+++ b/lib/beaker-pe.rb
@@ -23,13 +23,3 @@ end
 # Boilerplate DSL inclusion mechanism:
 # First we register our module with the Beaker DSL
 Beaker::DSL.register( Beaker::DSL::PE )
-
-# Second,We need to reload the DSL, but before we had reloaded
-# it in the global namespace, which result in errors colliding
-# with other gems rightfully not expecting beaker's dsl to
-# be available at the global level.
-module Beaker
-  class TestCase
-    include Beaker::DSL
-  end
-end

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1,4 +1,4 @@
-[ 'aio_defaults', 'pe_defaults', 'puppet_utils', 'windows_utils' ].each do |lib|
+[ 'aio_defaults', 'puppet_utils', 'windows_utils' ].each do |lib|
     require "beaker/dsl/install_utils/#{lib}"
 end
 require 'beaker-pe/install/feature_flags'

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1,5 +1,5 @@
 [ 'aio_defaults', 'puppet_utils', 'windows_utils' ].each do |lib|
-    require "beaker/dsl/install_utils/#{lib}"
+    require "beaker-puppet/install_utils/#{lib}"
 end
 require 'beaker-pe/install/feature_flags'
 require "beaker-answers"

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'scooter'
+require 'beaker-puppet'
 
 class ClassMixedWithDSLInstallUtils
   include Beaker::DSL::InstallUtils

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'scooter'
-require 'beaker-puppet'
 
 class ClassMixedWithDSLInstallUtils
   include Beaker::DSL::InstallUtils


### PR DESCRIPTION
Adds an explicit dependency on beaker-puppet, and changes require paths to make it clear what components are now pulled from beaker-puppet. Also removes the retroactive DSL extension injection, since that is accomplished in beaker now. (Not sure how that got missed first time around.)

Note that this PR will require a major version bump to depend on beaker 4.0 and beaker-puppet 1.0.