### PR TITLE
(MAINT) Require beaker first

### DIFF
--- a/lib/beaker-pe.rb
+++ b/lib/beaker-pe.rb
@@ -1,3 +1,5 @@
+require 'beaker'
+
 require 'stringify-hash'
 require 'beaker-pe/version'
 require 'beaker-pe/install/pe_defaults'


### PR DESCRIPTION
Some beaker-pe workflows do not "require 'beaker'" before beaker-pe. We should not assume that beaker is already in the environment: since it's a dependency, a simple require statement will take care of this.

Fixes errors like

~~~
NoMethodError: undefined method `register' for Beaker::DSL:Module
~~~