### PR TITLE
(PE-25091) Add configure_type_defaults_on on master during postgres i…

### DIFF
--- a/beaker-pe.gemspec
+++ b/beaker-pe.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
   s.add_runtime_dependency 'beaker-answers', '~> 0.0'
   s.add_runtime_dependency 'beaker-abs'
+  s.add_runtime_dependency 'beaker-vmpooler', '~> 1.0'
 
 end
 

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1500,6 +1500,8 @@ module Beaker
           pe_infrastructure = select_hosts({:roles => ['master', 'compile_master', 'dashboard', 'database', 'pe_postgres']}, hosts)
           non_infrastructure = hosts.reject{|host| pe_infrastructure.include? host}
 
+          configure_type_defaults_on([master])
+
           is_upgrade = (original_pe_ver(hosts[0]) != hosts[0][:pe_ver])
           step "Setup tmp installer directory and pe.conf" do
 


### PR DESCRIPTION
…nstall

With the jump to Beaker 4.0 the configure type defaults is no longer applied
automatticaly. We fixed that for most of our installs, but left it out on the
external postgres job. This PR adds that method to the job, which will fix a few
tests.