### PR TITLE
(PE-25010) Fix insecure repo config on Ubuntu 18.04

### DIFF
--- a/lib/beaker-pe/pe-client-tools/install_helper.rb
+++ b/lib/beaker-pe/pe-client-tools/install_helper.rb
@@ -99,7 +99,12 @@ module Beaker
               )
 
               scp_to host, list, '/etc/apt/sources.list.d'
-              create_remote_file(host, "/etc/apt/apt.conf.d/99trust-all", 'APT::Get::AllowUnauthenticated "true";')
+              if variant == 'ubuntu' && version.split('.').first.to_i >= 18
+                apt_conf_content = 'Acquire::AllowInsecureRepositories "true";'
+              else
+                apt_conf_content = 'APT::Get::AllowUnauthenticated "true";'
+              end
+              create_remote_file(host, '/etc/apt/apt.conf.d/99trust-all', apt_conf_content)
               on host, 'apt-get update'
             else
               host.logger.notify("No repository installation step for #{platform} yet...")


### PR DESCRIPTION
Prior to this commit `install_dev_repos_on` was attempting to use the
`APT::Get::AllowUnauthenticated` setting.
This commit updates `install_dev_repos_on` to use
`APT::Get::AllowUnauthenticated` on Ubuntu 18.04.

I'm surprised this hasn't caused more widespread failures already.