### PR TITLE
(PE-25091) Run configure_type_defaults_onon all infrastructure nodes

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1500,8 +1500,6 @@ module Beaker
           pe_infrastructure = select_hosts({:roles => ['master', 'compile_master', 'dashboard', 'database', 'pe_postgres']}, hosts)
           non_infrastructure = hosts.reject{|host| pe_infrastructure.include? host}
 
-          configure_type_defaults_on([master])
-
           is_upgrade = (original_pe_ver(hosts[0]) != hosts[0][:pe_ver])
           step "Setup tmp installer directory and pe.conf" do
 
@@ -1510,6 +1508,7 @@ module Beaker
             fetch_pe(pe_infrastructure,opts)
 
             [master, database, dashboard, pe_postgres].uniq.each do |host|
+              configure_type_defaults_on(host)
               prepare_host_installer_options(host)
 
               unless is_upgrade


### PR DESCRIPTION
Ubuntu1604 was not getting /opt/puppetlabs/bin set in the PATH on split PE nodes.
This caused testing failures while enabling MCO. This change fixes that.