### PR TITLE
(BKR-1519) update scooter dependency for beaker 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,7 @@ group :acceptance_testing do
   gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || '~> 1.3')
 end
 
-if ENV['GEM_SOURCE'] =~ /artifactory\.delivery\.puppetlabs\.net/
-  gem "scooter", *location_for(ENV['SCOOTER_VERSION'] || '~> 3.0')
-end
+gem "scooter", *location_for(ENV['SCOOTER_VERSION'] || '~> 4.3')
 
 gem 'deep_merge'
 


### PR DESCRIPTION
This PR updates the scooter ref in order to fully specify versions that use beaker 4. 

@puppetlabs/installer-and-management, is there a reason that this has been on scooter 3 even though scooter 4 has been out since March of last year? Is there a reason we should close this rather than move forward with it?