### PR TITLE
(CT-58) Properly install signed pe-client-tools package

### DIFF
--- a/lib/beaker-pe/pe-client-tools/install_helper.rb
+++ b/lib/beaker-pe/pe-client-tools/install_helper.rb
@@ -33,16 +33,17 @@ module Beaker
                 generic_install_msi_on(host, File.join(release_path, package_name), {}, {:debug => true})
               when /osx/
                 release_path = "#{opts[:dev_builds_url]}/#{product}/#{directory}/artifacts/apple/#{version}/#{opts[:puppet_collection]}/#{arch}"
-                package_base = product.dup
-                package_base << "-#{opts[:pe_client_tools_version]}"
-                package_name = package_base.dup
-                package_name << '-1' if opts[:pe_client_tools_version]
-                installer    = package_name + '-installer.pkg'
-                package_name << ".#{variant}#{version}.dmg"
+                package_base = "#{product}-#{opts[:pe_client_tools_version]}"
+                package_base << '-1' if opts[:pe_client_tools_version]
+
+                dmg = package_base + ".#{variant}#{version}.dmg"
                 copy_dir_local = File.join('tmp', 'repo_configs')
-                fetch_http_file(release_path, package_name, copy_dir_local)
-                scp_to host, File.join(copy_dir_local, package_name), host.external_copy_base
-                host.generic_install_dmg(package_name, package_base, installer)
+                fetch_http_file(release_path, dmg, copy_dir_local)
+                scp_to host, File.join(copy_dir_local, dmg), host.external_copy_base
+
+                package_name = package_base + '*'
+                installer = package_name + '-installer.pkg'
+                host.generic_install_dmg(dmg, package_name, installer)
               else
                 install_dev_repos_on(product, host, directory, '/tmp/repo_configs',{:dev_builds_url => opts[:dev_builds_url]})
                 host.install_package('pe-client-tools')

--- a/spec/beaker-pe/pe-client-tools/installer_helper_spec.rb
+++ b/spec/beaker-pe/pe-client-tools/installer_helper_spec.rb
@@ -102,7 +102,7 @@ describe ClassPEClientToolsMixedWithPatterns do
         hosts.each do |host|
           allow(subject).to receive(:fetch_http_file).with("http://builds.delivery.puppetlabs.net/pe-client-tools/#{opts[:pe_client_tools_sha]}/artifacts/apple/1111/PC1/x86_64", "pe-client-tools-#{opts[:pe_client_tools_version]}-1.osx1111.dmg", "tmp/repo_configs")
           allow(host).to receive(:external_copy_base)
-          expect(host).to receive(:generic_install_dmg).with("pe-client-tools-#{opts[:pe_client_tools_version]}-1.osx1111.dmg", "pe-client-tools-#{opts[:pe_client_tools_version]}", "pe-client-tools-#{opts[:pe_client_tools_version]}-1-installer.pkg")
+          expect(host).to receive(:generic_install_dmg).with("pe-client-tools-#{opts[:pe_client_tools_version]}-1.osx1111.dmg", "pe-client-tools-#{opts[:pe_client_tools_version]}-1*", "pe-client-tools-#{opts[:pe_client_tools_version]}-1*-installer.pkg")
           subject.install_pe_client_tools_on(host, opts)
         end
       end
@@ -111,7 +111,7 @@ describe ClassPEClientToolsMixedWithPatterns do
         hosts.each do |host|
           allow(subject).to receive(:fetch_http_file).with("http://builds.delivery.puppetlabs.net/pe-client-tools/#{tag_opts[:pe_client_tools_version]}/artifacts/apple/1111/PC1/x86_64", "pe-client-tools-#{tag_opts[:pe_client_tools_version]}-1.osx1111.dmg", "tmp/repo_configs")
           allow(host).to receive(:external_copy_base)
-          expect(host).to receive(:generic_install_dmg).with("pe-client-tools-#{tag_opts[:pe_client_tools_version]}-1.osx1111.dmg", "pe-client-tools-#{tag_opts[:pe_client_tools_version]}", "pe-client-tools-#{tag_opts[:pe_client_tools_version]}-1-installer.pkg")
+          expect(host).to receive(:generic_install_dmg).with("pe-client-tools-#{tag_opts[:pe_client_tools_version]}-1.osx1111.dmg", "pe-client-tools-#{tag_opts[:pe_client_tools_version]}-1*", "pe-client-tools-#{tag_opts[:pe_client_tools_version]}-1*-installer.pkg")
 
           subject.install_pe_client_tools_on(host, tag_opts)
         end


### PR DESCRIPTION
With signed dmgs, the directory the image mounts to includes the macOS
version. Previously, we were assuming that it would only include the
package version. We now use a glob when matching the package to install,
which makes this method robust when using either kind of dmg.