### PR TITLE
PE-25470 Update higgs installer option

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1407,8 +1407,10 @@ module Beaker
           if(use_meep?(pe_ver))
             if(version_is_less(pe_ver, '2018.1.3'))
               return '1'
-            else
+            elsif(version_is_less(pe_ver, '2019.0.2'))
               return '2'
+            else
+              return '3'
             end
           else
             return 'Y'

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -2479,6 +2479,9 @@ describe ClassMixedWithDSLInstallUtils do
     it 'returns 2 if the pe_ver is greater then 2018.1.3' do
       expect(subject.determine_higgs_answer('2018.2.0')).to eq('2')
     end
+    it 'returns 3 if the pe_ver is greater then 2019.0.1' do
+      expect(subject.determine_higgs_answer('2019.0.2')).to eq('3')
+    end
   end
 
   describe 'update_pe_conf' do


### PR DESCRIPTION
With 2019.0.2, the web install option changed to 3 instead of 2

