### PR TITLE
(maint) Fix insecure repo config on Ubuntu 18.04 ...again

### DIFF
--- a/lib/beaker-pe/pe-client-tools/install_helper.rb
+++ b/lib/beaker-pe/pe-client-tools/install_helper.rb
@@ -99,7 +99,8 @@ module Beaker
               )
 
               scp_to host, list, '/etc/apt/sources.list.d'
-              if variant == 'ubuntu' && version.split('.').first.to_i >= 18
+              # Ubuntu platform gets host['platform'].with_version_codename (see line 57)
+              if variant == 'ubuntu' && version == 'bionic'
                 apt_conf_content = 'Acquire::AllowInsecureRepositories "true";'
               else
                 apt_conf_content = 'APT::Get::AllowUnauthenticated "true";'


### PR DESCRIPTION
For ubuntu (and debian) the `version` is the codename. Previously the regex was expecting the numeric (for example we expected 18.04, not bionic) version. This commit generates the desired config to configure apt-get to ignore the fact that the repo where the test code lives is not signed.

Please delete any headings that don't apply to this Pull Request (PR).

#### What's this PR do?
#### Who would you like to review this PR?

@puppetlabs/integration, @puppetlabs/beaker (repo owners)

#### Should any of this be tested outside the normal PR CI cycle?
#### Any background context you want to provide?
#### Questions for reviewers?
