### PR TITLE
(PE-23663) Disable agent service on external postgres install

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -6,6 +6,7 @@ require "beaker-answers"
 require "timeout"
 require "json"
 require "deep_merge"
+
 module Beaker
   module DSL
     module InstallUtils
@@ -1554,6 +1555,10 @@ module Beaker
               [master, database, dashboard].uniq.each do |host|
                 execute_installer_cmd(host, opts)
               end
+          end
+
+          step "Stop agent service on infrastructure nodes" do
+            stop_agent_on(pe_infrastructure, :run_in_parallel => true)
           end
 
           step "First puppet run on infrastructure + postgres node" do

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1387,6 +1387,9 @@ describe ClassMixedWithDSLInstallUtils do
       allow(subject).to receive(:execute_installer_cmd).with(mono_master, {}).twice
       allow(subject).to receive(:execute_installer_cmd).with(pe_postgres, {}).once
 
+      allow(subject).to receive(:stop_agent_on).and_return(true)
+      expect(subject).to receive(:stop_agent_on).with([mono_master, pe_postgres], :run_in_parallel => true).once
+      
       allow(subject).to receive(:on).with(mono_master, "puppet agent -t", :acceptable_exit_codes=>[0, 2]).exactly(3).times
       allow(subject).to receive(:on).with(pe_postgres, "puppet agent -t", :acceptable_exit_codes=> [0, 2]).once
 
@@ -1413,6 +1416,10 @@ describe ClassMixedWithDSLInstallUtils do
       allow(subject).to receive(:is_expected_pe_postgres_failure?).and_return(true)
       allow(subject).to receive(:execute_installer_cmd).with(pe_postgres, {}).once
       expect(subject).to receive(:execute_installer_cmd).with(mono_master, {}).once.ordered
+
+      allow(subject).to receive(:stop_agent_on).and_return(true)
+      expect(subject).to receive(:stop_agent_on).with([mono_master, pe_postgres], :run_in_parallel => true).once
+
       allow(subject).to receive(:on).with(mono_master, "puppet agent -t", :acceptable_exit_codes=>[0, 2]).exactly(3).times
       allow(subject).to receive(:on).with(pe_postgres, "puppet agent -t", :acceptable_exit_codes=> [0, 2]).once
 
@@ -1454,6 +1461,10 @@ describe ClassMixedWithDSLInstallUtils do
       allow(subject).to receive(:execute_installer_cmd).with(mono_master, {}).once
       allow(subject).to receive(:execute_installer_cmd).with(pe_postgres, {}).once
 
+      allow(subject).to receive(:stop_agent_on).and_return(true)
+      expect(subject).to receive(:stop_agent_on).with([mono_master, pe_postgres], :run_in_parallel => true).once
+
+
       allow(subject).to receive(:on).with(mono_master, "puppet agent -t", :acceptable_exit_codes=>[0, 2]).twice
       allow(subject).to receive(:on).with(pe_postgres, "puppet agent -t", :acceptable_exit_codes=> [0, 2]).once
 
@@ -1476,6 +1487,9 @@ describe ClassMixedWithDSLInstallUtils do
       allow(subject).to receive(:execute_installer_cmd).with(split_database, {}).once
       allow(subject).to receive(:execute_installer_cmd).with(split_console, {}).once
       allow(subject).to receive(:execute_installer_cmd).with(pe_postgres, {}).once
+
+      allow(subject).to receive(:stop_agent_on).and_return(true)
+      expect(subject).to receive(:stop_agent_on).with([split_master, split_database, split_console, pe_postgres], :run_in_parallel => true).once
 
       allow(subject).to receive(:on).with(split_master, "puppet agent -t", :acceptable_exit_codes=>[0, 2]).twice
       allow(subject).to receive(:on).with(split_database, "puppet agent -t", :acceptable_exit_codes=>[0, 2]).once
@@ -1501,6 +1515,9 @@ describe ClassMixedWithDSLInstallUtils do
       allow(subject).to receive(:execute_installer_cmd).with(split_database, {}).once
       allow(subject).to receive(:execute_installer_cmd).with(split_console, {}).once
       allow(subject).to receive(:execute_installer_cmd).with(pe_postgres, {}).once
+
+      allow(subject).to receive(:stop_agent_on).and_return(true)
+      expect(subject).to receive(:stop_agent_on).with([split_master, split_database, split_console, pe_postgres], :run_in_parallel => true).once
 
       allow(subject).to receive(:on).with(split_master, "puppet agent -t", :acceptable_exit_codes=>[0, 2]).twice
       allow(subject).to receive(:on).with(split_database, "puppet agent -t", :acceptable_exit_codes=>[0, 2]).once


### PR DESCRIPTION
While other install types disable the agent service on all the nodes to prevent issues with testing, this was omitted from do_install_pe_with_pe_managed_external_postgres. This adds the step in just before the first post-install puppet agent run happens. Stopping the agent service on non-infra nodes is taken care of by the install_agents_only_on function.

Please delete any headings that don't apply to this Pull Request (PR).

#### What's this PR do?
#### Who would you like to review this PR?

@puppetlabs/integration, @puppetlabs/beaker (repo owners)

#### Should any of this be tested outside the normal PR CI cycle?
#### Any background context you want to provide?
#### Questions for reviewers?
