### PR TITLE
EExternal postgres to work with compile master

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1515,7 +1515,7 @@ module Beaker
 
         #Installs PE with a PE managed external postgres
         def do_install_pe_with_pe_managed_external_postgres(hosts, opts)
-          pe_infrastructure = select_hosts({:roles => ['master', 'compile_master', 'dashboard', 'database', 'pe_postgres']}, hosts)
+          pe_infrastructure = select_hosts({:roles => ['master', 'dashboard', 'database', 'pe_postgres']}, hosts)
           non_infrastructure = hosts.reject{|host| pe_infrastructure.include? host}
 
           is_upgrade = (original_pe_ver(hosts[0]) != hosts[0][:pe_ver])


### PR DESCRIPTION
During external postgres installation, puppet agent is not getting
installed on a compile_master node since it is added to the
infrastructure node array. Removing compile_master from infrastructure
nodes array will add that node to the agents array and puppet will be
installed.

