### PR TITLE
(PE-27037) Grab fips tarball when using redhatfips-7-x86_64

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -934,6 +934,7 @@ module Beaker
                 host['dist'] = "puppet-enterprise-#{version}"
               end
             end
+            host['dist'] = "puppet-enterprise-#{version}-#{host['packaging_platform']}" if host['packaging_platform'] =~ /redhatfips/
             host['working_dir'] = host.tmpdir(Time.new.strftime("%Y-%m-%d_%H.%M.%S"))
           end
         end


### PR DESCRIPTION
For testing reasons, the puppet agent team needs the platform tag to remain el-7-x86_64 when using redhatfips-7-x86_64 hosts. This sets the host['dist'] string to use the packaging_platform string rather than the platform string when packaging_platform is redhatfips.

If the platform tag ever changes to redhatfips, this commit should be reverted.
