### PR TITLE
(maint) Use packaging_platform when checking frictionless

### DIFF
--- a/beaker-pe.gemspec
+++ b/beaker-pe.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   # Documentation dependencies
   s.add_development_dependency 'yard'
   s.add_development_dependency 'markdown'
+  s.add_development_dependency 'activesupport', '~> 5.0'
   s.add_development_dependency 'thin'
 
   # Run time dependencies

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -790,7 +790,7 @@ module Beaker
               if host['roles'].include?('frictionless') &&  (! version_is_less(version, '3.2.0'))
                 # If We're *not* running the classic installer, we want
                 # to make sure the master has packages for us.
-                if host['platform'] != master['platform'] # only need to do this if platform differs
+                if host['packaging_platform'] != master['packaging_platform'] # only need to do this if platform differs
                   deploy_frictionless_to_master(host)
                 end
                 install_ca_cert_on(host, opts)
@@ -1884,7 +1884,7 @@ module Beaker
                agent_nodes.each do |agent|
                  # If We're *not* running the classic installer, we want
                  # to make sure the master has packages for us.
-                 if agent['platform'] != master['platform'] # only need to do this if platform differs
+                 if agent['packaging_platform'] != master['packaging_platform'] # only need to do this if platform differs
                    deploy_frictionless_to_master(agent)
                  end
                end

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1371,7 +1371,7 @@ describe ClassMixedWithDSLInstallUtils do
     let(:split_master) { make_host('mono_master', :pe_ver => '2017.2', :platform => 'ubuntu-16.04-x86_64', :roles => ['master', 'agent']) }
     let(:split_database) { make_host('split_database', :pe_ver => '2017.2', :platform => 'ubuntu-16.04-x86_64', :roles => ['database', 'agent']) }
     let(:split_console) { make_host('mono_master', :pe_ver => '2017.2', :platform => 'ubuntu-16.04-x86_64', :roles => ['dashboard', 'agent']) }
-    let(:agent) { make_host('agent', :pe_ver => '2017.2', :platform => 'el-7-x86_64', :roles => ['agent'])}
+    let(:agent) { make_host('agent', :pe_ver => '2017.2', :platform => 'el-7-x86_64', :packaging_platform => 'el-7-x86_64', :roles => ['agent'])}
 
     it 'will do a monolithic installation of PE with an external postgres that is managed by PE' do
       allow(subject).to receive(:fetch_pe).with([mono_master, pe_postgres], {}).and_return(true)
@@ -1602,7 +1602,7 @@ describe ClassMixedWithDSLInstallUtils do
 
   describe '#deploy_frictionless_to_master' do
     let(:master) { make_host('master', :pe_ver => '2017.2', :platform => 'ubuntu-16.04-x86_64', :roles => ['master', 'database', 'dashboard']) }
-    let(:agent) { make_host('agent', :pe_ver => '2017.2', :platform => 'el-7-x86_64', :roles => ['frictionless']) }
+    let(:agent) { make_host('agent', :pe_ver => '2017.2', :platform => 'el-7-x86_64', :packaging_platform => 'el-7-x86_64', :roles => ['frictionless']) }
     let(:compile_master) { make_host('agent', :pe_ver => '2017.2', :roles => ['frictionless', 'compile_master']) }
     let(:pe_compiler) { make_host('agent', :pe_ver => '2019.2', :roles => ['frictionless', 'pe_compiler']) }
     let(:dispatcher) { double('dispatcher') }
@@ -1972,9 +1972,9 @@ describe ClassMixedWithDSLInstallUtils do
   end
 
   describe 'simple_monolithic_install' do
-    let(:monolithic) { make_host('monolithic', :pe_ver => '2016.4', :platform => 'el-7-x86_64', :roles => [ 'master', 'database', 'dashboard' ]) }
-    let(:el_agent) { make_host('agent', :pe_ver => '2016.4', :platform => 'el-7-x86_64', :roles => ['frictionless']) }
-    let(:deb_agent) { make_host('agent', :pe_ver => '2016.4', :platform => 'debian-7-x86_64', :roles => ['frictionless']) }
+    let(:monolithic) { make_host('monolithic', :pe_ver => '2016.4', :platform => 'el-7-x86_64', :packaging_platform => 'el-7-x86_64', :roles => [ 'master', 'database', 'dashboard' ]) }
+    let(:el_agent) { make_host('agent', :pe_ver => '2016.4', :platform => 'el-7-x86_64', :packaging_platform => 'el-7-86_64', :roles => ['frictionless']) }
+    let(:deb_agent) { make_host('agent', :pe_ver => '2016.4', :platform => 'debian-7-x86_64', :packaging_platform => 'debian-7-x86_64', :roles => ['frictionless']) }
 
     before :each do
       allow(subject).to receive(:on)
@@ -2010,10 +2010,12 @@ describe ClassMixedWithDSLInstallUtils do
     let(:monolithic) { make_host('monolithic',
                                  :pe_ver => '2016.4',
                                  :platform => 'el-7-x86_64',
+                                 :packaging_platform => 'el-7-x86_64',
                                  :roles => ['master', 'database', 'dashboard']) }
     let(:agent) { make_host('agent',
                             :pe_ver => '2016.4',
                             :platform => 'el-7-x86_64',
+                            :packaging_platform => 'el-7-x86_64',
                             :roles => ['frictionless']) }
     before :each do
       allow(subject).to receive(:on)
@@ -2032,6 +2034,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'calls deploy_frictionless_to_master if agent platform is different from master' do
       agent['platform'] = 'deb-7-x86_64'
+      agent['packaging_platform'] = 'deb-7-x86_64'
       expect(subject).to receive(:deploy_frictionless_to_master)
       subject.install_agents_only_on([agent], opts)
     end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -26,6 +26,7 @@ end
 
 module HostHelpers
   HOST_DEFAULTS = { :platform => 'unix',
+                    :packaging_platform => 'unix',
                     :roles => ['agent'],
                     :snapshot => 'snap',
                     :ip => 'default.ip.address',


### PR DESCRIPTION
...agent platform against master platform because platform
doesn't distinguish between fips and non-fips el.