### PR TITLE
(QENG-7529) Add vmstat to vm resource check

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -533,6 +533,7 @@ module Beaker
           pe_infrastructure = select_hosts({:roles => ['master', 'compile_master', 'pe_compiler', 'dashboard', 'database']}, hosts)
           pe_infrastructure.each do |host|
             on host, "top -bn1", :accept_all_exit_codes => true
+            on host, "vmstat 1 1", :accept_all_exit_codes => true
           end
         end
 


### PR DESCRIPTION
This commit adds `vmstat` to the vm resource check so that we can get
more information about swap usage.