### PR TITLE
(RE-12858) Change delivery_host blocked for proxy tests to artifactory 

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -690,7 +690,7 @@ module Beaker
             step "Configuring #{host} to use proxy" do
               @osmirror_host = "osmirror.delivery.puppetlabs.net"
               @osmirror_host_ip = IPSocket.getaddress(@osmirror_host)
-              @delivery_host = "enterprise.delivery.puppetlabs.net"
+              @delivery_host = "artifactory.delivery.puppetlabs.net"
               @delivery_host_ip = IPSocket.getaddress(@delivery_host)
               @test_forge_host = "api-forge-aio02-petest.puppet.com"
               @test_forge_host_ip = IPSocket.getaddress(@test_forge_host)


### PR DESCRIPTION
This replaces e.d.p.n with artifactory.delivery.puppetlabs.net in the list of hosts that the config_hosts_for_proxy_access function blocks to simulate them being on the other side of the proxy.