### PR TITLE
(maint) Update Rake

### DIFF
--- a/beaker-pe.gemspec
+++ b/beaker-pe.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its'
   s.add_development_dependency 'fakefs', '~> 0.6', '< 0.14.0'
-  s.add_development_dependency 'rake', '~> 10.1'
+  s.add_development_dependency 'rake', '~> 12.3.3'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'pry', '~> 0.10'
 


### PR DESCRIPTION
CVE-2020-8130 requires us to update Rake.  