### PR TITLE
(maint) Update PE managed postgres steps

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1580,7 +1580,8 @@ module Beaker
               configure_type_defaults_on(host)
               prepare_host_installer_options(host)
 
-              unless is_upgrade
+              # On upgrade we don't want to update the postgre's pe.conf
+              unless (is_upgrade && host['roles'].include?('pe_postgres'))
                 setup_pe_conf(host, hosts, opts)
               end
             end

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -646,29 +646,6 @@ describe ClassMixedWithDSLInstallUtils do
     def slice_installer_options(host)
       host.host_hash.select { |k,v| [ :pe_installer_conf_file, :pe_installer_conf_setting].include?(k) }
     end
-
-    context 'when version < 2016.2.0' do
-      let(:pe_ver) { '3.8.5' }
-
-      it 'sets legacy settings' do
-        expect(slice_installer_options(host)).to eq(legacy_settings)
-      end
-    end
-
-    context 'when version >= 2016.2.0' do
-      let (:pe_ver) { '2016.2.0' }
-
-      it 'test use_meep?' do
-        expect(subject.use_meep?('3.8.5')).to eq(false)
-        expect(subject.use_meep?('2016.1.2')).to eq(false)
-        expect(subject.use_meep?('2016.2.0')).to eq(true)
-        expect(subject.use_meep?('2016.2.0-rc1-gabcdef')).to eq(true)
-      end
-
-      it 'sets meep settings' do
-        expect(slice_installer_options(host)).to eq(meep_settings)
-      end
-    end
   end
 
   RSpec.shared_examples 'test flag' do |flag_name|


### PR DESCRIPTION
For LEI split upgrades we need to update the pe.conf on the master in order
for a new feature flag to be set.
Previously we alwasy skipped updating the pe.conf on upgrades for all nodes.
For sure on the postgres node if we attempt to update the pe.conf things go
sideways. However in this scenario we only need to update the pe.conf for the
master.
So this PR adds in logic to ignore updating pe.conf on upgrades on postgres node.

Also removed some spec tests that broke with the change in beaker here: https://github.com/puppetlabs/beaker/commit/28089701b9b31901f2d4b5d119d8f1b2b1223f96.
The spec tests were around PE logic when installing/upgrading to PE 2016.2, which we haven't supported for a few years now.
