### PR TITLE
(maint) Remove the logic change around postgres pe conf updating

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1580,8 +1580,7 @@ module Beaker
               configure_type_defaults_on(host)
               prepare_host_installer_options(host)
 
-              # On upgrade we don't want to update the postgre's pe.conf
-              unless (is_upgrade && host['roles'].include?('pe_postgres'))
+              unless is_upgrade
                 setup_pe_conf(host, hosts, opts)
               end
             end


### PR DESCRIPTION
This broke split postgres for 2018.1.x
We're just going to fix this in pe_acceptance_tests where we update
the feature flag, it makes more sense there, and will cause less churn
in this gem.
