### PR TITLE
(maint) follow redirection in curl

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -292,7 +292,7 @@ module Beaker
               fetch_and_push_pe(host, path, filename, extension)
             else
               curlopts = opts[:use_proxy] ? " --proxy #{opts[:proxy_hostname]}:3128" : ""
-              on host, "cd #{host['working_dir']}; curl -O #{path}/#{filename}#{extension}#{curlopts}"
+              on host, "cd #{host['working_dir']}; curl -L -O #{path}/#{filename}#{extension}#{curlopts}"
             end
           end
         end
@@ -328,7 +328,7 @@ module Beaker
               on host, "cd #{host['working_dir']}; chmod 644 #{filename}#{extension}"
             elsif host.is_cygwin?
               curlopts = opts[:use_proxy] ? " --proxy #{opts[:proxy_hostname]}:3128" : ""
-              on host, "cd #{host['working_dir']}; curl -O #{path}/#{filename}#{extension}#{curlopts}"
+              on host, "cd #{host['working_dir']}; curl -L -O #{path}/#{filename}#{extension}#{curlopts}"
             else
               on host, powershell("$webclient = New-Object System.Net.WebClient;  $webclient.DownloadFile('#{path}/#{filename}#{extension}','#{host['working_dir']}\\#{filename}#{extension}')")
             end
@@ -381,7 +381,7 @@ module Beaker
                 command_file_push = 'cat '
               else
                 curlopts = opts[:use_proxy] ? "--proxy #{opts[:proxy_hostname]}:3128 " : ""
-                command_file_push = "curl #{curlopts}#{path}/"
+                command_file_push = "curl -L #{curlopts}#{path}/"
               end
               on host, "cd #{host['working_dir']}; #{command_file_push}#{filename}#{extension} | #{unpack}"
 

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1091,7 +1091,7 @@ describe ClassMixedWithDSLInstallUtils do
       path = unixhost['pe_dir']
       filename = "#{ unixhost['dist'] }"
       extension = '.tar'
-      expect( subject ).to receive( :on ).with( unixhost, "cd #{ unixhost['working_dir'] }; curl #{ path }/#{ filename }#{ extension } | tar -xvf -" ).once
+      expect( subject ).to receive( :on ).with( unixhost, "cd #{ unixhost['working_dir'] }; curl -L #{ path }/#{ filename }#{ extension } | tar -xvf -" ).once
       subject.fetch_pe( [unixhost], {} )
     end
 
@@ -1121,7 +1121,7 @@ describe ClassMixedWithDSLInstallUtils do
       path = unixhost['pe_dir']
       filename = "#{ unixhost['dist'] }"
       extension = '.tar.gz'
-      expect( subject ).to receive( :on ).with( unixhost, "cd #{ unixhost['working_dir'] }; curl #{ path }/#{ filename }#{ extension } | gunzip | tar -xvf -" ).once
+      expect( subject ).to receive( :on ).with( unixhost, "cd #{ unixhost['working_dir'] }; curl -L #{ path }/#{ filename }#{ extension } | gunzip | tar -xvf -" ).once
       subject.fetch_pe( [unixhost], {} )
     end
 
@@ -1167,7 +1167,7 @@ describe ClassMixedWithDSLInstallUtils do
       path = machost['pe_dir']
       filename = "#{ machost['dist'] }"
       extension = '.dmg'
-      expect( subject ).to receive( :on ).with( machost, "cd #{ machost['working_dir'] }; curl -O #{ path }/#{ filename }#{ extension }" ).once
+      expect( subject ).to receive( :on ).with( machost, "cd #{ machost['working_dir'] }; curl -L -O #{ path }/#{ filename }#{ extension }" ).once
       subject.fetch_pe( [machost], {} )
     end
 


### PR DESCRIPTION
#### What's this PR do?
It allows pe-client-tools CI to install pe-server
#### Should any of this be tested outside the normal PR CI cycle?
#### Any background context you want to provide?
When I tried to run pe-client-tools CI, curl is not following redirected path where packages were available
#### Questions for reviewers?
