### PR TITLE
(CT-123) Package install with version

### DIFF
--- a/lib/beaker-pe/pe-client-tools/install_helper.rb
+++ b/lib/beaker-pe/pe-client-tools/install_helper.rb
@@ -47,6 +47,15 @@ module Beaker
               else
                 install_dev_repos_on(product, host, directory, '/tmp/repo_configs',{:dev_builds_url => opts[:dev_builds_url]})
                 host.install_package('pe-client-tools')
+                if host['platform'] =~ /cisco|centos|redhat|eos|sles|el-|fedora-(2[2-9]|3[0-9])/
+                  host.exec(Command.new('rpm -q pe-client-tools')) do |command|
+                    raise "Wanted version not installed." unless command.stdout =~ /-#{opts[:pe_client_tools_version]}/
+                  end
+                elsif host['platform'] =~ /ubuntu|debian|cumulus|huaweios/
+                  host.exec(Command.new("apt-cache policy pe-client-tools | sed -n -e 's/Installed: //p'")) do |command|
+                    raise "Wanted version not installed." unless command.stdout =~ /-#{opts[:pe_client_tools_version]}/
+                  end
+                end
             end
           end
         end


### PR DESCRIPTION
PE Clinet Tools pipeline does not know how to downgrade packages.  For
example, if the pe-client-tools package that is to be installed is older
than the pe-client-tools that comes with puppet enterprise, it will not
install the required vesion.

This PR makes an additional check to see if the correct pe-client-tools package was installed.