### PR TITLE
(PE-29140) Add logic to skip installs on preloaded images

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -661,7 +661,7 @@ module Beaker
           register_feature_flags!(opts)
           generate_installer_conf_file_for(master, all_hosts, opts)
           step "Install PE on master" do
-            on master, installer_cmd(master, opts)
+            on master, installer_cmd(master, opts) if master['template'] !~ /-preload/
           end
 
           step "Stop agent on master" do


### PR DESCRIPTION
This pr adds logic to skip the installer script run on a host that was created from a monolithic PE preloaded template.

