### PR TITLE
(maint) Silence batch output in pe-client-tools

### DIFF
--- a/lib/beaker-pe/pe-client-tools/executable_helper.rb
+++ b/lib/beaker-pe/pe-client-tools/executable_helper.rb
@@ -127,6 +127,7 @@ module Beaker
               #TODO does this need to be more detailed to pass exit codes????
               # TODO make batch file direct output to separate file
               batch_contents =<<-EOS
+@echo off
 call #{tool_executable} #{args.join(' ')}
               EOS
 


### PR DESCRIPTION
#### What's this PR do?
Add `@echo off` to the batch script to ensure we don't include the command in the output.

#### Any background context you want to provide?
Commands that are part of pe-client-tools are executed on Windows with a batch script.

Without this change, the beaker command output will always include the called command, which causes inconsistencies between Windows and other platforms.

This helper file is probably only used in pe-client-tools projects so it's unlikely that this change will break something. In any case, having the command be part of beaker output is wrong and should be fixed.