### PR TITLE
(maint) Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
-#This Repository is maintained by both the beaker and installer teams, depending on the location of the changes
+#This Repository is maintained by both the beaker, installer, and Night's Watch teams, depending on the location of the changes
 * @puppetlabs/beaker
 /lib/beaker-pe/install @puppetlabs/installer-and-management
+/lib/beaker-pe/pe-client-tools @puppetlabs/night-s-watch
 /spec/beaker-pe/install @puppetlabs/installer-and-management


### PR DESCRIPTION
Add Night's Watch as owners of the pe-client-tools subpath of beaker-pe.