### PR TITLE
(maint) Pin simplecov to 0.18.5

### DIFF
--- a/beaker-pe.gemspec
+++ b/beaker-pe.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-its'
   s.add_development_dependency 'fakefs', '~> 0.6', '< 0.14.0'
   s.add_development_dependency 'rake', '~> 12.3.3'
-  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'simplecov', '= 0.18.5'
   s.add_development_dependency 'pry', '~> 0.10'
 
   # Documentation dependencies


### PR DESCRIPTION
Simplecov 0.19 and later requires Ruby 2.5. Since we test with Ruby 2.4.4 in addition to 2.5, this is pinned back to 0.18.5.