### PR TITLE
(PE-31503) AIX frictionless install without old TLS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ end
 group :acceptance_testing do
   gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4.0')
   gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || '~> 1.3')
+  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.8')
 end
 
 gem "scooter", *location_for(ENV['SCOOTER_VERSION'] || '~> 4.3')

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -139,7 +139,7 @@ module Beaker
         #Return true if tlsv1 protocol needs to be enforced
         #param [Host] the host
         def require_tlsv1?(host)
-          tlsv1_platforms = [/aix/, /el-5/, /solaris-1[0,1]-[i,x]/, /sles-11/,/windows-2008/]
+          tlsv1_platforms = [/el-5/, /solaris-1[0,1]-[i,x]/, /sles-11/,/windows-2008/]
           return tlsv1_platforms.any? {|platform_regex| host['platform'] =~ platform_regex}
         end
 
@@ -211,7 +211,7 @@ module Beaker
             end
             if use_puppet_ca_cert
               curl_opts << '--cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem'
-            elsif host['platform'] !~ /aix/
+            else
               curl_opts << '-k'
             end
 

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -263,7 +263,7 @@ describe ClassMixedWithDSLInstallUtils do
       expecting = [
         "FRICTIONLESS_TRACE='true'",
         "export FRICTIONLESS_TRACE",
-        "cd /tmp && curl -O --tlsv1 https://testmaster:8140/packages/current/install.bash && bash install.bash"
+        "cd /tmp && curl -O --tlsv1 -k https://testmaster:8140/packages/current/install.bash && bash install.bash"
       ].join("; ")
 
       expect( subject.frictionless_agent_installer_cmd( host, {}, '2016.4.0' ) ).to eq(expecting)


### PR DESCRIPTION
Previously when curling on a AIX host we were using an outdated curl
version that didn't support TLSv3. This meant we had to explictily install
PE with letting in old 1.2 ciphers.
We now have an updated curl and no longer require that. AIX hosts can now
be installed like other platforms, with just the curl -k option.