### PR TITLE
(PE-34061) Specify powershell execution policy during install

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -209,7 +209,7 @@ module Beaker
               protocol_to_use = '[System.Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12'
             end
 
-            cmd = %Q{powershell -c "cd #{host['working_dir']};#{protocol_to_use};#{cert_validator};\\$webClient = New-Object System.Net.WebClient;\\$webClient.DownloadFile('https://#{downloadhost}:8140/packages/current/install.ps1', '#{host['working_dir']}/install.ps1');#{host['working_dir']}/install.ps1 -verbose #{frictionless_install_opts.join(' ')}"}
+            cmd = %Q{powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -c "cd #{host['working_dir']};#{protocol_to_use};#{cert_validator};\\$webClient = New-Object System.Net.WebClient;\\$webClient.DownloadFile('https://#{downloadhost}:8140/packages/current/install.ps1', '#{host['working_dir']}/install.ps1');#{host['working_dir']}/install.ps1 -verbose #{frictionless_install_opts.join(' ')}"}
           else
             curl_opts = %w{-O}
             if version_is_less(pe_version, '2019.1.0') || require_tlsv1?(host)

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -272,7 +272,7 @@ describe ClassMixedWithDSLInstallUtils do
     it 'generates a PS1 frictionless install command for windows' do
       host['platform'] = 'windows-2012-64'
       protocol = ''
-      expecting = "powershell -c \"" +
+      expecting = "powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -c \"" +
                   [
                     "cd /tmp",
                     "#{protocol}",
@@ -290,7 +290,7 @@ describe ClassMixedWithDSLInstallUtils do
       host['puppetpath'] = '/PuppetLabs/puppet/etc'
       host['use_puppet_ca_cert'] = true
       protocol = ''
-      expecting = "powershell -c \"" +
+      expecting = "powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -c \"" +
       [
         "cd /tmp",
         "#{protocol}",
@@ -311,7 +311,7 @@ describe ClassMixedWithDSLInstallUtils do
     it 'generates a PS1 frictionless install command for windows with Tls12 protocol' do
       host['platform'] = 'windows-20012-64'
       protocol = '[System.Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12'
-      expecting = "powershell -c \"" +
+      expecting = "powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -c \"" +
                   [
                     "cd /tmp",
                     "#{protocol}",
@@ -327,7 +327,7 @@ describe ClassMixedWithDSLInstallUtils do
     it 'generates a PS1 frictionless install command for windows-2008 without Tls12 protocol' do
       host['platform'] = 'windows-2008-64'
       protocol = ''
-      expecting = "powershell -c \"" +
+      expecting = "powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -c \"" +
                   [
                     "cd /tmp",
                     "#{protocol}",


### PR DESCRIPTION
beaker-pe could not frictionless install puppet on Window 11, because Windows
client/desktop OSes default to `Restricted` powershell execution policy[1],
and that disables execution of all `.ps1` files (and more).

Now we specify the execution policy during install, which matches the same
options that beaker's `powershell` DSL method uses[2]. We unfortunately can't
use beaker directly because `installer_cmd` needs to return the "command to
execute" instead of executing it directly.

This wasn't an issue in Windows 10 and earlier, because the execution policy
was changed globally in the image.

[1] https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7.2#restricted
[2] https://github.com/voxpupuli/beaker/blob/4.36.0/lib/beaker/dsl/wrappers.rb#L41