### PR TITLE
(PE-34110) Add ability to inject flags to be passed to configure action

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -258,6 +258,9 @@ module Beaker
               pe_cmd += " -y"
             end
 
+            configure_flags = host['configure_flags'] || opts[:configure_flags]
+            pe_cmd += " -- #{configure_flags}" if configure_flags
+
             # If we are doing an upgrade from 2016.2.0,
             # we can assume there will be a valid pe.conf in /etc that we can re-use.
             # We also expect that any custom_answers specified to beaker have been


### PR DESCRIPTION
We need the ability to pass flags into the configure action in order to skip the versioned_deploy check (e.g. 'puppet-enterprise-installer -y -- --skip-versioned-deploy-check'). When this is set on the host object or in options, this string containing the flags will be added to the installer command.