### PR TITLE
(maint) Add GCP 10.253/16 scratchpad hosts to proxy firewall

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -823,6 +823,8 @@ module Beaker
               # The next two lines clear the rest of the internal puppet lan
               on host, "iptables -A OUTPUT -p tcp -d 10.16.0.0/16 -j ACCEPT"
               on host, "iptables -A OUTPUT -p tcp -d 10.32.0.0/16 -j ACCEPT"
+              # And for GCP scratchpad hosts
+              on host, "iptables -A OUTPUT -p tcp -d 10.253.0.0/16 -j ACCEPT"
               # This allows udp on a port bundler requires
               on host, 'iptables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT'
               # Next two lines allow host to access itself via localhost or 127.0.0.1


### PR DESCRIPTION
This allows dev vms in our scratchpad projects to reach the isolated test vms when running beaker with proxy testing setup.

