### PR TITLE
(maint) Fix duplicate solaris ca cert

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,2 @@
-#This Repository is maintained by both the release engineering, and installer teams, depending on the location of the changes
-*  @puppetlabs/release-engineering
-/lib/beaker-pe/install @puppetlabs/installer-and-management
-/lib/beaker-pe/pe-client-tools @puppetlabs/installer-and-management
-/spec/beaker-pe/install @puppetlabs/installer-and-management
+#This Repository is maintained by the release engineering, skeletor, and nimbus teams
+*  @puppetlabs/release-engineering @puppetlabs/skeletor @puppetlabs/nimbus

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1396,10 +1396,10 @@ gKDWHrO8Dw9TdSmq6hN35N6MgSGtBxBHEa2HPQfRdbzP82Z+
 EOM
           hosts.each do |host|
             if host.platform=~ /solaris-11(\.2)?-(i386|sparc)/
-              create_remote_file(host, "DigiCertTrustedRootG4.crt.pem", digicert)
-              on(host, 'chmod a+r /root/DigiCertTrustedRootG4.crt.pem')
-              on(host, 'cp -p /root/DigiCertTrustedRootG4.crt.pem /etc/certs/CA/')
-              on(host, 'rm /root/DigiCertTrustedRootG4.crt.pem')
+              create_remote_file(host, "DigiCert_Trusted_Root_G4.pem", digicert)
+              on(host, 'chmod a+r /root/DigiCert_Trusted_Root_G4.pem')
+              on(host, 'cp -p /root/DigiCert_Trusted_Root_G4.pem /etc/certs/CA/')
+              on(host, 'rm /root/DigiCert_Trusted_Root_G4.pem')
               on(host, '/usr/sbin/svcadm restart /system/ca-certificates')
               timeout = 60
               counter = 0


### PR DESCRIPTION
#### What's this PR do?
The DigiCert root CA G4 cert is named `DigiCert_Trusted_Root_G4.pem` on a fully patched Solaris 11.4 system. This resolves a duplicate certificate error after restarting ca-certificates.

#### Should any of this be tested outside the normal PR CI cycle?
Tested on jenkins staging instance.

#### Any background context you want to provide?
Solaris 11 test targets recently updated to fully patched 11.4 install

#### Questions for reviewers?
Prefer keeping this method to support older Solaris installs, or remove completely?
