### PR TITLE
Allow beaker 5

### DIFF
--- a/beaker-pe.gemspec
+++ b/beaker-pe.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'thin'
 
   # Run time dependencies
-  s.add_runtime_dependency 'beaker', '~>4.0'
+  s.add_runtime_dependency 'beaker', '>= 4.0', '< 6'
   s.add_runtime_dependency 'beaker-puppet', '>=1', '<3'
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
   s.add_runtime_dependency 'beaker-answers', '~> 0.0'


### PR DESCRIPTION
This allows the latest beaker major version as dependency, beaker 5.
