### PR TITLE
(PE-36506) Use AIX 7.2 packages for 2023 STS stream

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -495,9 +495,9 @@ module Beaker
           # For some platforms (e.g, redhatfips), packaging_platfrom is set and should
           # be used as the primary source of truth for the platform string.
           platform = host['packaging_platform'] || host['platform']
-          # We don't have a separate AIX 7.2 build, so it is
+          # We don't have a separate AIX 7.2 build prior to 2023, so it is
           # classified as 7.1 for pe_repo purposes
-          if platform == "aix-7.2-power"
+          if platform == "aix-7.2-power" && version_is_less(master[:pe_ver], '2023.0.0')
             platform = "aix-7.1-power"
           end
           klass = platform.gsub(/-/, '_').gsub(/\./,'')


### PR DESCRIPTION
AIX 7.1 is EOL, so we are moving to 7.2 for the STS stream. We still build on 7.1 for the LTS (2021.7). This commit updates the logic for classification to deploy a frictionless agent to use 7.1 builds for LTS and 7.2 builds for STS.

Please delete any headings that don't apply to this Pull Request (PR).

#### What's this PR do?
#### Should any of this be tested outside the normal PR CI cycle?
#### Any background context you want to provide?
#### Questions for reviewers?
