### PR TITLE
(RE-15688) Add working nodeset for beaker-rspec tests

### DIFF
--- a/acceptance/tests/install_smoke_test.rb
+++ b/acceptance/tests/install_smoke_test.rb
@@ -7,11 +7,6 @@ hosts.each do |host|
   on host, facter('--help')
 end
 
-step 'puppet install smoketest: verify \'hiera --help\' can be successfully called on all hosts'
-hosts.each do |host|
-  on host, hiera('--help')
-end
-
 step 'puppet install smoketest: verify \'puppet help\' can be successfully called on all hosts'
 hosts.each do |host|
   on host, puppet('help')

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,10 @@
+---
+HOSTS:
+  rocky8-64-1:
+    platform: el-8-x86_64
+    hypervisor: vmpooler
+    template: rocky-8-x86_64-pooled
+    roles:
+    - agent
+CONFIG:
+  pooling_api: 'https://vmpooler-prod.k8s.infracore.puppet.net/api/v3'


### PR DESCRIPTION
This adds a beaker-hostgenerator nodeset file to be used with the beaker-rspec tests in order to override the `pooling_api` and `template` keys, since I don't see a way to override the `template` directly through beaker-hostgenerator.