### PR TITLE
Add dependabot, release prep, and label reusable workflows from release-engineering-repo-standards

### DIFF
--- a/.github/workflows/auto_release_prep.yml
+++ b/.github/workflows/auto_release_prep.yml
@@ -1,0 +1,11 @@
+name: Automated release prep
+
+on:
+  workflow_dispatch:
+
+jobs:
+  auto_release_prep:
+    uses: puppetlabs/release-engineering-repo-standards/.github/workflows/auto_release_prep.yml@v1
+    secrets: inherit
+    with:
+      version-file-path: lib/beaker-pe/version.rb

--- a/.github/workflows/dependabot_merge.yml
+++ b/.github/workflows/dependabot_merge.yml
@@ -1,0 +1,8 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+jobs:
+  dependabot_merge:
+    uses: puppetlabs/release-engineering-repo-standards/.github/workflows/dependabot_merge.yml@v1
+    secrets: inherit

--- a/.github/workflows/ensure_label.yml
+++ b/.github/workflows/ensure_label.yml
@@ -1,0 +1,8 @@
+name: Ensure label
+
+on: pull_request
+
+jobs:
+  ensure_label:
+    uses: puppetlabs/release-engineering-repo-standards/.github/workflows/ensure_label.yml@v1
+    secrets: inherit


### PR DESCRIPTION
Add reusable workflows.

Putting back in draft until we fix the tests in jenkins.