### PR TITLE
(maint) Remove dependabot_merge action

### DIFF
--- a/.github/workflows/auto_release_prep.yml
+++ b/.github/workflows/auto_release_prep.yml
@@ -8,4 +8,5 @@ jobs:
     uses: puppetlabs/release-engineering-repo-standards/.github/workflows/auto_release_prep.yml@v1
     secrets: inherit
     with:
+      project-type: ruby
       version-file-path: lib/beaker-pe/version.rb

--- a/.github/workflows/dependabot_merge.yml
+++ b/.github/workflows/dependabot_merge.yml
@@ -1,8 +1,0 @@
-name: Dependabot auto-merge
-
-on: pull_request
-
-jobs:
-  dependabot_merge:
-    uses: puppetlabs/release-engineering-repo-standards/.github/workflows/dependabot_merge.yml@v1
-    secrets: inherit

--- a/release-prep
+++ b/release-prep
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 # bundle install
-docker run -it --rm \
+docker run -t --rm \
   -v $(pwd):/app \
   ruby:2.7-slim-bullseye \
   /bin/bash -c 'apt-get update -qq && apt-get install -y --no-install-recommends build-essential git make && cd /app && gem install bundler && bundle install --jobs 3; echo "LOCK_FILE_UPDATE_EXIT_CODE=$?"'
 
 # Update Changelog
-docker run -it --rm -e CHANGELOG_GITHUB_TOKEN -v $(pwd):/usr/local/src/your-app \
+docker run -t --rm -e CHANGELOG_GITHUB_TOKEN -v $(pwd):/usr/local/src/your-app \
   githubchangeloggenerator/github-changelog-generator:1.16.2 \
   github_changelog_generator --future-release $(grep STRING lib/beaker-pe/version.rb |rev |cut -d "'" -f2 |rev)


### PR DESCRIPTION
Remove the dependabot_merge action because the jenkins job uses multi-configuration/upstream & downstream jobs, the check reports as "passed" after an successful stage in the chain, resulting in the pull request being auto-merged prematurely.

Evidently, when overriding workflow parameters with keyword `with`, it no longer inherits other default params.

Also need to remove the interactive option from the release prep script to work in github Actions