### PR TITLE
(PE-37704) Allow for SLES-11 (Intel) builds to be installed in PE 2021.7.x for testing

### DIFF
--- a/.github/workflows/auto_release_prep.yml
+++ b/.github/workflows/auto_release_prep.yml
@@ -1,0 +1,12 @@
+name: Automated release prep
+
+on:
+  workflow_dispatch:
+
+jobs:
+  auto_release_prep:
+    uses: puppetlabs/release-engineering-repo-standards/.github/workflows/auto_release_prep.yml@v1
+    secrets: inherit
+    with:
+      project-type: ruby
+      version-file-path: lib/beaker-pe/version.rb

--- a/.github/workflows/ensure_label.yml
+++ b/.github/workflows/ensure_label.yml
@@ -1,0 +1,8 @@
+name: Ensure label
+
+on: pull_request
+
+jobs:
+  ensure_label:
+    uses: puppetlabs/release-engineering-repo-standards/.github/workflows/ensure_label.yml@v1
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         echo "Found version $version from lib/beaker-pe/version.rb"
 
     - name: Get Current Version
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       id: cv
       with:
         script: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
     - name: check lock
       run: '[ -f "Gemfile.lock" ] && echo "package lock file exists, skipping" || bundle lock'
     # install java
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: 'temurin' # See 'Supported distributions' for available options
         java-version: '17'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [3.0.0](https://github.com/puppetlabs/beaker-pe/tree/3.0.0) (2024-02-07)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-pe/compare/2.16.0...3.0.0)
+
+**Implemented enhancements:**
+
+- Bump beaker from 4.40.2 to 4.41.1 [\#248](https://github.com/puppetlabs/beaker-pe/pull/248) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump scooter from 4.4.0 to 4.5.0 [\#242](https://github.com/puppetlabs/beaker-pe/pull/242) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+**Fixed bugs:**
+
+- Bump beaker from 4.41.1 to 4.41.2 [\#249](https://github.com/puppetlabs/beaker-pe/pull/249) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump activesupport from 7.1.1 to 7.1.2 [\#240](https://github.com/puppetlabs/beaker-pe/pull/240) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+**Merged pull requests:**
+
+- Bump rspec from 3.12.0 to 3.13.0 [\#253](https://github.com/puppetlabs/beaker-pe/pull/253) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump activesupport from 7.1.2 to 7.1.3 [\#251](https://github.com/puppetlabs/beaker-pe/pull/251) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump actions/setup-java from 3 to 4 [\#245](https://github.com/puppetlabs/beaker-pe/pull/245) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump actions/github-script from 6 to 7 [\#241](https://github.com/puppetlabs/beaker-pe/pull/241) ([dependabot[bot]](https://github.com/apps/dependabot))
+
 ## [2.16.0](https://github.com/puppetlabs/beaker-pe/tree/2.16.0) (2023-12-05)
 
 [Full Changelog](https://github.com/puppetlabs/beaker-pe/compare/2.15.0...2.16.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    beaker-pe (2.16.0)
+    beaker-pe (3.0.0)
       beaker (>= 4.0, < 6)
       beaker-abs
-      beaker-answers (~> 0.0)
+      beaker-answers (~> 1.0)
       beaker-puppet (>= 1, < 3)
       beaker-vmpooler (~> 1.0)
       stringify-hash (~> 0.0.0)
@@ -12,7 +12,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.1)
+    activesupport (7.1.3.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -24,9 +24,9 @@ GEM
       tzinfo (~> 2.0)
     ansi (1.5.0)
     ast (2.4.2)
-    base64 (0.1.1)
+    base64 (0.2.0)
     bcrypt_pbkdf (1.1.0)
-    beaker (4.40.2)
+    beaker (4.41.2)
       beaker-hostgenerator
       ed25519 (~> 1.0)
       hocon (~> 1.0)
@@ -45,30 +45,29 @@ GEM
       beaker (~> 4.0)
       ed25519 (>= 1.2, < 2.0)
       vmfloaty (>= 1.0, < 2)
-    beaker-answers (0.29.0)
+    beaker-answers (1.0.0)
       hocon (~> 1.0)
       require_all (>= 1.3.2, < 3.1.0)
       stringify-hash (~> 0.0.0)
-    beaker-hostgenerator (2.2.3)
+    beaker-hostgenerator (2.9.1)
       deep_merge (~> 1.0)
     beaker-puppet (2.0.0)
       beaker (~> 4.1)
       oga (~> 3.4)
     beaker-vmpooler (1.4.0)
       stringify-hash (~> 0.0.0)
-    bigdecimal (3.1.4)
+    bigdecimal (3.1.6)
     coderay (1.1.3)
     commander (4.6.0)
       highline (~> 2.0.0)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     daemons (1.4.1)
     deep_merge (1.2.2)
-    diff-lcs (1.5.0)
+    diff-lcs (1.5.1)
     docile (1.4.0)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
-    drb (2.1.1)
+    domain_name (0.6.20240107)
+    drb (2.2.0)
       ruby2_keywords
     ed25519 (1.3.0)
     eventmachine (1.2.7)
@@ -107,10 +106,10 @@ GEM
       domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    in-parallel (1.0.0)
+    in-parallel (1.0.1)
     inifile (3.0.0)
     iniparser (1.0.1)
-    json (2.6.3)
+    json (2.7.1)
     kramdown (2.4.0)
       rexml
     logutils (0.6.1)
@@ -120,13 +119,13 @@ GEM
       textutils (>= 0.10.0)
     method_source (1.0.0)
     minitar (0.9)
-    minitest (5.20.0)
-    multipart-post (2.3.0)
-    mutex_m (0.1.2)
-    net-ldap (0.16.3)
+    minitest (5.22.2)
+    multipart-post (2.4.0)
+    mutex_m (0.2.0)
+    net-ldap (0.19.0)
     net-scp (4.0.0)
       net-ssh (>= 2.6.5, < 8.0.0)
-    net-ssh (7.2.0)
+    net-ssh (7.2.1)
     oga (3.4)
       ast
       ruby-ll (~> 2.1)
@@ -136,39 +135,39 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rack (2.2.7)
+    rack (2.2.8.1)
     rake (13.1.0)
     require_all (3.0.0)
     rexml (3.2.6)
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.2)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
+      rspec-support (~> 3.13.0)
     rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.0)
     rsync (1.0.9)
-    ruby-ll (2.1.2)
+    ruby-ll (2.1.3)
       ansi
       ast
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    scooter (4.4.0)
-      beaker (~> 4.0)
-      faraday (~> 1.5)
-      faraday-cookie_jar (~> 0.0, >= 0.0.7)
+    scooter (4.5.4)
+      beaker
+      faraday
+      faraday-cookie_jar (>= 0.0.7)
       faraday_middleware (~> 1.2)
-      json (>= 2.3.0)
-      net-ldap (~> 0.16.0)
+      json
+      net-ldap (~> 0.16)
       test-unit
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -177,7 +176,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     stringify-hash (0.0.2)
-    test-unit (3.5.7)
+    test-unit (3.6.1)
       power_assert
     textutils (1.4.0)
       activesupport
@@ -188,16 +187,13 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    thor (1.2.2)
+    thor (1.3.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.8.2)
-    vmfloaty (1.8.0)
+    vmfloaty (1.8.1)
       commander (>= 4.4.3, < 4.7.0)
       faraday (~> 1.5, >= 1.5.1)
-    yard (0.9.34)
+    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
@@ -223,4 +219,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.4.22
+   2.3.23

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ with spec testing by running the `test:spec:coverage` rake task.
 
 Acceptance tests live in the `acceptance/tests` folder.  These are Beaker tests,
 & are dependent on having Beaker installed. Note that this will happen with a
-`bundle install` execution, but can be avoided if you're not looking to run 
+`bundle install` execution, but can be avoided if you're not looking to run
 acceptance tests by ignoring the `acceptance_testing` gem group.
 
 You can run the acceptance testing suite by invoking the `test:acceptance` rake
@@ -76,6 +76,11 @@ provided hosts file for acceptance under the `acceptance/config` directory. If
 you'd like to provide your own hosts file, set the `CONFIG` environment variable.
 
 ## Releasing
+
+Prerequisites (without these steps you will almost certainly hit API rate limits):
+
+1. Generate [an API token](https://github.com/settings/tokens) with repository permissions and authorize the Puppet organization after generating.
+2. Export that token as `CHANGELOG_GITHUB_TOKEN`
 
 Open a release prep PR and run the release action:
 

--- a/beaker-pe.gemspec
+++ b/beaker-pe.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'beaker', '>= 4.0', '< 6'
   s.add_runtime_dependency 'beaker-puppet', '>=1', '<3'
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
-  s.add_runtime_dependency 'beaker-answers', '~> 0.0'
+  s.add_runtime_dependency 'beaker-answers', '~> 1.0'
   s.add_runtime_dependency 'beaker-abs'
   s.add_runtime_dependency 'beaker-vmpooler', '~> 1.0'
 

--- a/lib/beaker-pe/version.rb
+++ b/lib/beaker-pe/version.rb
@@ -3,7 +3,7 @@ module Beaker
     module PE
 
       module Version
-        STRING = '2.16.0'
+        STRING = '3.0.0'
       end
 
     end

--- a/release-prep
+++ b/release-prep
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 # bundle install
-docker run -it --rm \
+docker run -t --rm \
   -v $(pwd):/app \
   ruby:2.7-slim-bullseye \
   /bin/bash -c 'apt-get update -qq && apt-get install -y --no-install-recommends build-essential git make && cd /app && gem install bundler && bundle install --jobs 3; echo "LOCK_FILE_UPDATE_EXIT_CODE=$?"'
 
 # Update Changelog
-docker run -it --rm -e CHANGELOG_GITHUB_TOKEN -v $(pwd):/usr/local/src/your-app \
+docker run -t --rm -e CHANGELOG_GITHUB_TOKEN -v $(pwd):/usr/local/src/your-app \
   githubchangeloggenerator/github-changelog-generator:1.16.2 \
   github_changelog_generator --future-release $(grep STRING lib/beaker-pe/version.rb |rev |cut -d "'" -f2 |rev)


### PR DESCRIPTION
  - Define method to install sles-11 rpm from agent-downloads since it is not present in PE.
  - Define rspec to test the above method.
  - Adds a new mock sles11 host to the hosts list for the rspec.
  - Expect get_mco_setting() to be received twice instead of once for the subject, one for osx host (already existed before this commit), another for sles11 host (added in this commit).

