### PR TITLE
(PE-38111) 3.0.1 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [3.0.1](https://github.com/puppetlabs/beaker-pe/tree/3.0.1) (2024-04-08)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-pe/compare/3.0.0...3.0.1)
+
+**Implemented enhancements:**
+
+- \(PE-37704\) Allow for SLES-11 \(Intel\) builds to be installed in PE 2021.7.x for testing [\#259](https://github.com/puppetlabs/beaker-pe/pull/259) ([shubhamshinde360](https://github.com/shubhamshinde360))
+
+**Merged pull requests:**
+
+- Bump yard from 0.9.35 to 0.9.36 [\#258](https://github.com/puppetlabs/beaker-pe/pull/258) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump rack from 2.2.8 to 2.2.8.1 [\#257](https://github.com/puppetlabs/beaker-pe/pull/257) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump yard from 0.9.34 to 0.9.35 [\#256](https://github.com/puppetlabs/beaker-pe/pull/256) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump activesupport from 7.1.3 to 7.1.3.2 [\#255](https://github.com/puppetlabs/beaker-pe/pull/255) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump scooter from 4.5.0 to 4.5.4 [\#254](https://github.com/puppetlabs/beaker-pe/pull/254) ([dependabot[bot]](https://github.com/apps/dependabot))
+
 ## [3.0.0](https://github.com/puppetlabs/beaker-pe/tree/3.0.0) (2024-02-07)
 
 [Full Changelog](https://github.com/puppetlabs/beaker-pe/compare/2.16.0...3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    beaker-pe (3.0.0)
+    beaker-pe (3.0.1)
       beaker (>= 4.0, < 6)
       beaker-abs
       beaker-answers (~> 1.0)

--- a/lib/beaker-pe/version.rb
+++ b/lib/beaker-pe/version.rb
@@ -3,7 +3,7 @@ module Beaker
     module PE
 
       module Version
-        STRING = '3.0.0'
+        STRING = '3.0.1'
       end
 
     end


### PR DESCRIPTION
 - This release is required to add support for sles-11 (main) builds to be installed in CI.