### PR TITLE
Release 2.18.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    beaker-pe (2.17.0)
+    beaker-pe (2.18.0)
       beaker (>= 4.0, < 6)
       beaker-abs
       beaker-answers (~> 0.0)

--- a/lib/beaker-pe/version.rb
+++ b/lib/beaker-pe/version.rb
@@ -3,7 +3,7 @@ module Beaker
     module PE
 
       module Version
-        STRING = '2.17.0'
+        STRING = '2.18.0'
       end
 
     end


### PR DESCRIPTION
Beaker 2.18.0 contains methods backported from beaker 3.x: https://github.com/puppetlabs/beaker-pe/pull/279

This is to fix the acceptance tests for 2021.7.x, which uses beaker 2.x