### PR TITLE
(PE-38685) Beaker 6 upgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    beaker-pe (3.2.0)
-      beaker (>= 4.0, < 6)
+    beaker-pe (3.3.0)
+      beaker (>= 4.0, < 7)
       beaker-abs
       beaker-answers (~> 1.0)
       beaker-puppet (>= 1)

--- a/beaker-pe.gemspec
+++ b/beaker-pe.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'thin'
 
   # Run time dependencies
-  s.add_runtime_dependency 'beaker', '>= 4.0', '< 6'
+  s.add_runtime_dependency 'beaker', '>= 4.0', '< 7'
   s.add_runtime_dependency 'beaker-puppet', '>=1'
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
   s.add_runtime_dependency 'beaker-answers', '~> 1.0'

--- a/lib/beaker-pe/version.rb
+++ b/lib/beaker-pe/version.rb
@@ -3,7 +3,7 @@ module Beaker
     module PE
 
       module Version
-        STRING = '3.2.0'
+        STRING = '3.3.0'
       end
 
     end


### PR DESCRIPTION
#### What's this PR do?
Upgrades beaker to 6, kicks off a release (3.2 -> 3.3)

#### Any background context you want to provide?
As part of the beaker 6 upgrade for pe_acceptance_tests, I had to bump the version on beaker-pe. My local testing of pe_acceptance_tests pointed at my local directory for beaker-pe, so I verified this works.

##### Details of my test:
In pe_acceptance_tests, locally, I pointed beaker-pe at my local directory (mentioned above), then pointed at beaker-puppet 4.0 (to get the beaker 6 transitive deps worked out). 

Then I visited [this CI run](https://jenkins-enterprise.delivery.puppetlabs.net/view/pe-integration/view/pe-main/job/enterprise_pe-acceptance-tests_integration-system_pe_lei-mono_nightly_main/LAYOUT=centos7-64mcd-64pe_compiler.fa-64fa,LEGACY_AGENT_VERSION=NONE,PLATFORM=NONE,SCM_BRANCH=main,UPGRADE_FROM=NONE,UPGRADE_TO_VERSION=NONE,label=k8s-beaker/lastCompletedBuild/consoleFull) and yoinked a set of commands to run locally:

1. beaker-hostgenerator
2. beaker init
3. `pe_ver` and `pe_dir` for the hosts.cfg

The `bundle exec beaker exec` command completed with a return value of 0, all tests passing. :shipit: 