### PR TITLE
(maint): Added support for v2 agent download url

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -342,7 +342,7 @@ module Beaker
           extension = ".rpm"
           host.install_package_with_rpm("#{path}/#{filename}#{extension}")
         end
- 
+
         #Determine the PE package to download/upload on a windows host, download/upload that package onto the host.
         #Assumed file name format: puppet-enterprise-3.3.0-rc1-559-g97f0833.msi
         # @param [Host] host The windows host to download/upload and unpack PE onto
@@ -1076,7 +1076,11 @@ module Beaker
             pe_ver = host[:pe_ver] || opts[:pe_ver] || '4.0.0-rc1'
             opts = sanitize_opts(opts)
             opts[:download_url] =
-              "#{opts[:pe_promoted_builds_url]}/puppet-agent/#{pe_ver}/#{opts[:puppet_agent_version]}/repos"
+              if Gem::Version.new(pe_ver) > Gem::Version.new('2023.7.0')
+                "#{opts[:pe_promoted_builds_url]}/v2/agent/#{pe_ver}/#{opts[:puppet_agent_version]}/repos"
+              else
+                "#{opts[:pe_promoted_builds_url]}/puppet-agent/#{pe_ver}/#{opts[:puppet_agent_version]}/repos"
+              end
             opts[:copy_base_local]    ||= File.join('tmp', 'repo_configs')
             opts[:copy_dir_external]  ||= host.external_copy_base
             opts[:puppet_collection] ||= puppet_collection_for(:puppet_agent, opts[:puppet_agent_version])


### PR DESCRIPTION
This PR is created to fix the issue with the following [pipeline](https://jenkins-enterprise.delivery.puppetlabs.net/job/enterprise_pe-acceptance-tests_integration-system_pe_with-legacy-agents_nightly_main/LAYOUT=redhat8-64mcd-redhat8-64legacy_agent.a,LEGACY_AGENT_VERSION=2023.8.0%253A8.8.1,PLATFORM=NONE,SCM_BRANCH=main,UPGRADE_FROM=NONE,UPGRADE_TO_VERSION=NONE,label=k8s-beaker/1438/consoleFull), which is failing because it cannot generate a URL that supports its v2 version.

<img width="1494" alt="image" src="https://github.com/user-attachments/assets/8b15dd2e-0be7-4767-9f2e-17710f166bad">

The URL https://pm.puppet.com/puppet-agent/2023.8.0/8.8.1/repos/puppet-agent-el-8-x86_64.tar.gz should be updated to https://pm.puppet.com/v2/agent/2023.8.0/8.8.1/repos/puppet-agent-el-8-x86_64.tar.gz.