### PR TITLE
(maint) Update version to 3.6.0 and update changelog for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.6.0](https://github.com/puppetlabs/beaker-pe/tree/3.6.0) (2025-11-20)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-pe/compare/3.5.0...3.6.0)
+
+**Implemented enhancements:**
+
+- \[PE-42706\]: Add support for installing Puppet agent on Solaris 10 SPARC hosts [\#289](https://github.com/puppetlabs/beaker-pe/pull/289) ([span786](https://github.com/span786))
+
 ## [3.5.0](https://github.com/puppetlabs/beaker-pe/tree/3.5.0) (2025-04-15)
 
 [Full Changelog](https://github.com/puppetlabs/beaker-pe/compare/3.4.0...3.5.0)

--- a/lib/beaker-pe/version.rb
+++ b/lib/beaker-pe/version.rb
@@ -3,7 +3,7 @@ module Beaker
     module PE
 
       module Version
-        STRING = '3.5.0'
+        STRING = '3.6.0'
       end
 
     end


### PR DESCRIPTION

#### What's this PR do?
This PR introduces the release of a new gem version, 3.6.0, which includes the latest updates and enhancements. The purpose of this release is to ensure that other projects can leverage these changes and stay aligned with the most recent improvements.
