### PR TITLE
(maint) Update version to 3.6.1 and add changelog entry for enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.6.1](https://github.com/puppetlabs/beaker-pe/tree/3.6.1) (2025-11-21)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-pe/compare/3.6.0...3.6.1)
+
+**Implemented enhancements:**
+
+- \[PE-41604\]: Update Solaris 10 SPARC package installation method in PE Utils [\#291](https://github.com/puppetlabs/beaker-pe/pull/291) ([span786](https://github.com/span786))
+
 ## [3.6.0](https://github.com/puppetlabs/beaker-pe/tree/3.6.0) (2025-11-20)
 
 [Full Changelog](https://github.com/puppetlabs/beaker-pe/compare/3.5.0...3.6.0)

--- a/lib/beaker-pe/version.rb
+++ b/lib/beaker-pe/version.rb
@@ -3,7 +3,7 @@ module Beaker
     module PE
 
       module Version
-        STRING = '3.6.0'
+        STRING = '3.6.1'
       end
 
     end


### PR DESCRIPTION

#### What's this PR do?
This PR introduces the release of a new gem version, 3.6.1, which includes the latest updates and enhancements. The purpose of this release is to ensure that other projects can leverage these changes and stay aligned with the most recent improvements.
