### PR TITLE
(BOLT-150) Extend support 
to latest 7.x beaker

### DIFF
--- a/.github/workflows/ensure_label.yml
+++ b/.github/workflows/ensure_label.yml
@@ -1,8 +1,42 @@
+# This workflow was originally pointing to a shared workflow in the puppetlabs/release-engineering-repo-standards repository. 
+# However, it has been copied here since the shared workflow is no longer publicly accessible.
+#
+# on: pull_request
+# jobs:
+#   ensure_label:
+#     uses: puppetlabs/release-engineering-repo-standards/.github/workflows/ensure_label.yml@v1
+#     secrets: inherit
+
 name: Ensure label
 
-on: pull_request
+on: 
+  pull_request:
 
 jobs:
-  ensure_label:
-    uses: puppetlabs/release-engineering-repo-standards/.github/workflows/ensure_label.yml@v1
-    secrets: inherit
+  label_exists:
+    name: Label Must Exist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Labels
+        uses: actions/github-script@v6
+        with:
+          script: |
+            async function getPullRequest() {
+              // Get current pull request labels
+              const { data: { labels } } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.number,
+              });
+
+              // Log found label names
+              for (const label of labels) {
+                core.info(`Found label named '${label.name}' on pull request number ${context.payload.number}`);
+              };
+
+              // Fail workflow if no labels exist
+              labelsExist = (labels.length === 0) ? false : true;
+              if (!labelsExist) core.setFailed(`Please ensure that a label exists on pull request number ${context.payload.number}`);
+            }
+
+            getPullRequest();

--- a/beaker-pe.gemspec
+++ b/beaker-pe.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'thin'
 
   # Run time dependencies
-  s.add_runtime_dependency 'beaker', '>= 4.0', '< 7'
+  s.add_runtime_dependency 'beaker', '>= 4.0', '< 8'
   s.add_runtime_dependency 'beaker-puppet', '>=1'
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
   s.add_runtime_dependency 'beaker-answers', '~> 1.0'


### PR DESCRIPTION
## Problem

The Debian 13 platform has been added to Vanagon so that projects like bolt-vanagon-private are now successfully building new Debian 13 artifacts.  Unfortunately, our acceptance tests are failins beause we are using an old `2.x` version of `beaker-hostgenerator`.  Since debian 13 support has been added to the new `3.x` beaker-hostgenerator, we need to upgrade.  The easiest solution is to upgrade our `beaker` from version `6.x` to `7.x`.

Unfortunately, beaker cannot yet be upgraded because `beaker-puppet`, `beaker-pe`, and `beaker-abs` currently constrain Beaker to older versions.

## Solution

Therefore, this PR extends the constraint on `beaker` and fixes the issue.

## Testing

See the comment below with full replication steps of the testing
