### PR TITLE
(PE-45082) Broaden is_expected_pe_postgres_failure? allowlist

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -2084,7 +2084,7 @@ EOM
                 execute_installer_cmd(master, opts)
               rescue Beaker::Host::CommandFailure => e
                 unless is_expected_pe_postgres_failure?(master)
-                  raise "Install on master failed in an unexpected manner"
+                  raise "Install on master failed in an unexpected manner: #{e.message}"
                 end
               end
             end
@@ -2132,14 +2132,23 @@ EOM
         def is_expected_pe_postgres_failure?(host)
           installer_log_dir = '/var/log/puppetlabs/installer'
           latest_installer_log_file = on(host, "ls -1t #{installer_log_dir} | head -n1").stdout.chomp
-          # As of PE Irving (PE 2018.1.x), these are the only two expected errors
+          # The initial master install pass runs before pe-postgres is fully
+          # up, so it's expected to fail: the RBAC/console database isn't
+          # reachable yet, and depending on timing any core PE service
+          # (pe-console-services, pe-puppetdb, pe-puppetserver, etc.) may
+          # not (re)start before this pass' own timeouts trip. All of these
+          # are recoverable by the later "Install/Upgrade postgres service"
+          # and "Finish install/upgrade" steps, so they shouldn't fail the
+          # test. Match the service-startup failure class generically
+          # rather than enumerating individual services/ports here.
           allowed_errors = ["The operation could not be completed because RBACs database has not been initialized",
             "Timeout waiting for the database pool to become ready",
-            "Systemd restart for pe-console-services failed",
-            "Execution of.*service pe-console-services.*: Reload timed out after 120 seconds"]
+            "Systemd (start|restart) for pe-\\S+ failed",
+            "Execution of.*service pe-console-services.*: Reload timed out after 120 seconds",
+            "Connection refused"]
 
           allowed_errors.each do |error|
-            if(on(host, "grep '#{error}' #{installer_log_dir}/#{latest_installer_log_file}", :acceptable_exit_codes => [0,1]).exit_code == 0)
+            if(on(host, "grep -E '#{error}' #{installer_log_dir}/#{latest_installer_log_file}", :acceptable_exit_codes => [0,1]).exit_code == 0)
               return true
             end
           end

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -1305,76 +1305,61 @@ describe ClassMixedWithDSLInstallUtils do
   describe 'is_expected_pe_postgres_failure? method' do
     let(:mono_master) { make_host('mono_master', :pe_ver => '2017.2', :platform => 'ubuntu-16.04-x86_64', :roles => ['master', 'database', 'dashboard']) }
 
-    it 'will return true if it is the RBAC database string matcher' do
+    let(:zero_exit_code_mock) do
+      mock = Object.new
+      allow(mock).to receive(:exit_code).and_return(0)
+      mock
+    end
+    let(:one_exit_code_mock) do
+      mock = Object.new
+      allow(mock).to receive(:exit_code).and_return(1)
+      mock
+    end
+
+    def stub_installer_log_greps(all_but: nil)
       @installer_log_file_name = Beaker::Result.new( {}, '' )
       @installer_log_file_name.stdout = "installer_log_name"
-      zero_exit_code_mock = Object.new
-      allow(zero_exit_code_mock).to receive(:exit_code).and_return(0)
-      one_exit_code_mock = Object.new
-      allow(one_exit_code_mock).to receive(:exit_code).and_return(1)
       allow(subject).to receive(:on).with(mono_master, "ls -1t /var/log/puppetlabs/installer | head -n1").and_return(@installer_log_file_name)
-      allow(subject).to receive(:on).with(mono_master, "grep 'The operation could not be completed because RBACs database has not been initialized' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(zero_exit_code_mock)
-      allow(subject).to receive(:on).with(mono_master, "grep 'Timeout waiting for the database pool to become ready' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
-      allow(subject).to receive(:on).with(mono_master, "grep 'Systemd restart for pe-console-services failed' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
-      allow(subject).to receive(:on).with(mono_master, "grep 'Execution of.*service pe-console-services.*: Reload timed out after 120 seconds' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+
+      patterns = ["The operation could not be completed because RBACs database has not been initialized",
+        "Timeout waiting for the database pool to become ready",
+        "Systemd (start|restart) for pe-\\S+ failed",
+        "Execution of.*service pe-console-services.*: Reload timed out after 120 seconds",
+        "Connection refused"]
+
+      patterns.each do |pattern|
+        result = (pattern == all_but) ? zero_exit_code_mock : one_exit_code_mock
+        allow(subject).to receive(:on).with(mono_master, "grep -E '#{pattern}' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(result)
+      end
+    end
+
+    it 'will return true if it is the RBAC database string matcher' do
+      stub_installer_log_greps(all_but: "The operation could not be completed because RBACs database has not been initialized")
       expect(subject.is_expected_pe_postgres_failure?(mono_master)). to eq(true)
     end
 
     it 'will return true if it is the database pool timeout string matcher' do
-      @installer_log_file_name = Beaker::Result.new( {}, '' )
-      @installer_log_file_name.stdout = "installer_log_name"
-      zero_exit_code_mock = Object.new
-      allow(zero_exit_code_mock).to receive(:exit_code).and_return(0)
-      one_exit_code_mock = Object.new
-      allow(one_exit_code_mock).to receive(:exit_code).and_return(1)
-      allow(subject).to receive(:on).with(mono_master, "ls -1t /var/log/puppetlabs/installer | head -n1").and_return(@installer_log_file_name)
-      allow(subject).to receive(:on).with(mono_master, "grep 'The operation could not be completed because RBACs database has not been initialized' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
-      allow(subject).to receive(:on).with(mono_master, "grep 'Timeout waiting for the database pool to become ready' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(zero_exit_code_mock)
-      allow(subject).to receive(:on).with(mono_master, "grep 'Systemd restart for pe-console-services failed' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
-      allow(subject).to receive(:on).with(mono_master, "grep 'Execution of.*service pe-console-services.*: Reload timed out after 120 seconds' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+      stub_installer_log_greps(all_but: "Timeout waiting for the database pool to become ready")
       expect(subject.is_expected_pe_postgres_failure?(mono_master)). to eq(true)
     end
 
-    it 'will return true if it is the systemd restart of cosnole-services failure matcher' do
-      @installer_log_file_name = Beaker::Result.new( {}, '' )
-      @installer_log_file_name.stdout = "installer_log_name"
-      zero_exit_code_mock = Object.new
-      allow(zero_exit_code_mock).to receive(:exit_code).and_return(0)
-      one_exit_code_mock = Object.new
-      allow(one_exit_code_mock).to receive(:exit_code).and_return(1)
-      allow(subject).to receive(:on).with(mono_master, "ls -1t /var/log/puppetlabs/installer | head -n1").and_return(@installer_log_file_name)
-      allow(subject).to receive(:on).with(mono_master, "grep 'The operation could not be completed because RBACs database has not been initialized' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
-      allow(subject).to receive(:on).with(mono_master, "grep 'Timeout waiting for the database pool to become ready' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
-      allow(subject).to receive(:on).with(mono_master, "grep 'Systemd restart for pe-console-services failed' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(zero_exit_code_mock)
-      allow(subject).to receive(:on).with(mono_master, "grep 'Execution of.*service pe-console-services.*: Reload timed out after 120 seconds' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+    it 'will return true if it is the systemd start/restart of a pe-* service failure matcher (e.g. pe-console-services, pe-puppetdb, pe-puppetserver)' do
+      stub_installer_log_greps(all_but: "Systemd (start|restart) for pe-\\S+ failed")
       expect(subject.is_expected_pe_postgres_failure?(mono_master)). to eq(true)
     end
 
     it 'will return true if it is the console-services reload timeout string matcher' do
-      @installer_log_file_name = Beaker::Result.new( {}, '' )
-      @installer_log_file_name.stdout = "installer_log_name"
-      zero_exit_code_mock = Object.new
-      allow(zero_exit_code_mock).to receive(:exit_code).and_return(0)
-      one_exit_code_mock = Object.new
-      allow(one_exit_code_mock).to receive(:exit_code).and_return(1)
-      allow(subject).to receive(:on).with(mono_master, "ls -1t /var/log/puppetlabs/installer | head -n1").and_return(@installer_log_file_name)
-      allow(subject).to receive(:on).with(mono_master, "grep 'The operation could not be completed because RBACs database has not been initialized' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
-      allow(subject).to receive(:on).with(mono_master, "grep 'Timeout waiting for the database pool to become ready' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
-      allow(subject).to receive(:on).with(mono_master, "grep 'Systemd restart for pe-console-services failed' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
-      allow(subject).to receive(:on).with(mono_master, "grep 'Execution of.*service pe-console-services.*: Reload timed out after 120 seconds' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(zero_exit_code_mock)
+      stub_installer_log_greps(all_but: "Execution of.*service pe-console-services.*: Reload timed out after 120 seconds")
+      expect(subject.is_expected_pe_postgres_failure?(mono_master)). to eq(true)
+    end
+
+    it 'will return true if it is the connection refused matcher' do
+      stub_installer_log_greps(all_but: "Connection refused")
       expect(subject.is_expected_pe_postgres_failure?(mono_master)). to eq(true)
     end
 
     it 'will return false if no error messages are matched' do
-      @installer_log_file_name = Beaker::Result.new( {}, '' )
-      @installer_log_file_name.stdout = "installer_log_name"
-      one_exit_code_mock = Object.new
-      allow(one_exit_code_mock).to receive(:exit_code).and_return(1)
-      allow(subject).to receive(:on).with(mono_master, "ls -1t /var/log/puppetlabs/installer | head -n1").and_return(@installer_log_file_name)
-      allow(subject).to receive(:on).with(mono_master, "grep 'The operation could not be completed because RBACs database has not been initialized' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
-      allow(subject).to receive(:on).with(mono_master, "grep 'Timeout waiting for the database pool to become ready' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
-      allow(subject).to receive(:on).with(mono_master, "grep 'Systemd restart for pe-console-services failed' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
-      allow(subject).to receive(:on).with(mono_master, "grep 'Execution of.*service pe-console-services.*: Reload timed out after 120 seconds' /var/log/puppetlabs/installer/installer_log_name", :acceptable_exit_codes=>[0, 1]).and_return(one_exit_code_mock)
+      stub_installer_log_greps
       expect(subject.is_expected_pe_postgres_failure?(mono_master)). to eq(false)
     end
   end
@@ -1458,7 +1443,7 @@ describe ClassMixedWithDSLInstallUtils do
       expect(subject).to receive(:execute_installer_cmd).with(mono_master, {}).and_raise(Beaker::Host::CommandFailure).once.ordered
       allow(subject).to receive(:is_expected_pe_postgres_failure?).and_return(false)
 
-      expect{ subject.do_install_pe_with_pe_managed_external_postgres([mono_master, pe_postgres, agent], {}) }.to raise_error(RuntimeError, "Install on master failed in an unexpected manner")
+      expect{ subject.do_install_pe_with_pe_managed_external_postgres([mono_master, pe_postgres, agent], {}) }.to raise_error(RuntimeError, /\AInstall on master failed in an unexpected manner: /)
     end
 
     it 'will do a monolithic upgrade of PE with an external postgres that is managed by PE' do


### PR DESCRIPTION
## Summary

- `do_install_pe_with_pe_managed_external_postgres`'s first master install pass is *expected* to fail while `pe-postgres` is still coming up (step comment: "Initial master install, expected to fail due to RBAC database not being initialized"). Whether that failure is tolerated is gated by `is_expected_pe_postgres_failure?`, whose `allowed_errors` list was a hardcoded set of exact strings from PE 2018.1.x that only recognized `pe-console-services` wording, and specifically "restart" rather than "start".
- This caused intermittent hard failures on the PEZ smoke `sles15-64mcd-64agent,pe_postgres` axis: `pe-puppetdb`/`pe-puppetserver` first-pass startup timeouts against the cold external-postgres host didn't match any allowlist entry, even though the identical underlying condition self-heals via the later `Install/Upgrade postgres service` and `Finish install/upgrade` steps in passing runs.
- Generalizes the allowlist to match the failure *class* (`Systemd (start|restart) for pe-\S+ failed`, plus a general `Connection refused`) instead of enumerating specific services, so it isn't a one-line-per-service maintenance burden every time a different core PE service is the one slow to connect.
- Includes the actual `Beaker::Host::CommandFailure` message in the raised error for easier future debugging.
- See PE-45082 for full investigation context, evidence trail, and longer-term follow-up options (denylist-of-fatal-errors redesign; PE-side systemd start-timeout/retry fix) that are out of scope for this PR.

## Test plan

- [x] `bundle exec rspec spec/beaker-pe/install/pe_utils_spec.rb` — 225 examples, 0 failures
- [x] Updated/added spec coverage for the generalized `pe-*` service pattern and the new `Connection refused` pattern
- [ ] Verify against a live PEZ smoke re-run on the `sles15-64mcd-64agent,pe_postgres` axis once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)