### PR TITLE
(maint) prepare for release 3.6.3

### DIFF
--- a/lib/beaker-pe/version.rb
+++ b/lib/beaker-pe/version.rb
@@ -3,7 +3,7 @@ module Beaker
     module PE
 
       module Version
-        STRING = '3.6.2'
+        STRING = '3.6.3'
       end
 
     end


### PR DESCRIPTION
## Summary

- Version bump to prep the next release, picking up #303 (PE-45082 external-postgres allowlist fix).
- Matches the release-prep pattern of f65257d (3.6.2): version.rb only, no CHANGELOG.md entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)