### PR TITLE
(PE-41009) Fall back to agent-downloads when promoted agent is missing from public mirror

### DIFF
--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1120,6 +1120,36 @@ NOASK
           raise RuntimeError("#{host.class} not one of Beaker::(Windows|Mac|Unix)::Host")
         end
 
+        # Fetch a promoted puppet-agent package into copy_dir_local. Tries the
+        # primary (pm.puppet.com/S3) promoted mirror first; if that returns a
+        # 404 — newer agents (>= 8.11.0) are no longer published there — fall
+        # back to the internal agent-downloads host. Any non-404 failure is
+        # re-raised unchanged.
+        #
+        # @param [String] release_path Primary base URL, already including the
+        #   /v2/agent/<pe_ver>/<agent_ver>/repos suffix and release_path_end
+        # @param [String] release_path_end Platform suffix ('' unix, '/windows')
+        # @param [String] download_file The package file name
+        # @param [String] copy_dir_local Local destination directory
+        # @param [String] agent_version The puppet-agent version being installed
+        # @api private
+        def fetch_promoted_agent_with_fallback(release_path, release_path_end, download_file, copy_dir_local, agent_version)
+          download_uri = URI.parse("#{release_path}/#{download_file}")
+          redirect = Net::HTTP.start(download_uri.host) { |http| http.head(download_uri.path).response['location'] }
+          primary_base = redirect ? redirect.chomp("/#{download_file}") : release_path
+
+          begin
+            fetch_http_file(primary_base, download_file, copy_dir_local)
+          rescue => e
+            raise unless e.message.include?('404')
+
+            fallback_base = "#{AGENT_DOWNLOADS_URL}/#{agent_version}/repos#{release_path_end}"
+            logger.warn("Promoted puppet-agent not found at #{primary_base}/#{download_file} (#{e.message}); " \
+                        "falling back to #{fallback_base}/#{download_file}")
+            fetch_http_file(fallback_base, download_file, copy_dir_local)
+          end
+        end
+
         # Install shared repo of the puppet-agent on the given host(s).  Downloaded from
         # location of the form PE_PROMOTED_BUILDS_URL/PE_VER/puppet-agent/AGENT_VERSION/repo
         #
@@ -1166,12 +1196,7 @@ NOASK
 
             onhost_copied_download = File.join(onhost_copy_base, download_file)
             onhost_copied_file = File.join(onhost_copy_base, release_file)
-            download_uri = URI.parse("#{release_path}/#{download_file}")
-            if (redirect = Net::HTTP.start(download_uri.host) { |http| http.head(download_uri.path).response['location'] })
-              fetch_http_file(redirect.chomp("/#{download_file}"), download_file, copy_dir_local)
-            else
-              fetch_http_file(release_path, download_file, copy_dir_local)
-            end
+            fetch_promoted_agent_with_fallback(release_path, release_path_end, download_file, copy_dir_local, opts[:puppet_agent_version])
             scp_to host, File.join(copy_dir_local, download_file), onhost_copy_base
 
             if variant == 'windows'

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -43,6 +43,13 @@ module Beaker
         NODE_CONF_PATH = "#{MEEP_DATA_DIR}/conf.d/nodes"
         BEAKER_MEEP_TMP = "pe_conf"
 
+        # Base URL for promoted puppet-agent packages on the internal
+        # build-output host. Newer promoted agents (>= 8.11.0) are no longer
+        # published to the public pm.puppet.com / S3 mirror; el/windows installs
+        # fall back here. This is the same host the sles-11 and
+        # solaris-10-sparc install paths already use.
+        AGENT_DOWNLOADS_URL = 'http://agent-downloads.delivery.puppetlabs.net/puppet-agent'.freeze
+
         # @!macro [new] common_opts
         #   @param [Hash{Symbol=>String}] opts Options to alter execution.
         #   @option opts [Boolean] :silent (false) Do not produce log output
@@ -332,7 +339,7 @@ module Beaker
         # @api private
         def agent_package_common_vars(puppet_agent_ver, opts)
           {
-            agent_downloads_url: "http://agent-downloads.delivery.puppetlabs.net/puppet-agent",
+            agent_downloads_url: AGENT_DOWNLOADS_URL,
             master_aio_version: puppet_fact(master, 'aio_agent_build'),
             stream: opts[:puppet_collection] || "puppet#{puppet_agent_ver[0]}"
           }

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -106,6 +106,13 @@ describe ClassMixedWithDSLInstallUtils do
     end
   end
 
+  context 'AGENT_DOWNLOADS_URL' do
+    it 'points at the internal agent-downloads host' do
+      expect(Beaker::DSL::InstallUtils::PEUtils::AGENT_DOWNLOADS_URL)
+        .to eq('http://agent-downloads.delivery.puppetlabs.net/puppet-agent')
+    end
+  end
+
   context '#prep_host_for_upgrade' do
 
     it 'sets per host options before global options' do

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -113,6 +113,66 @@ describe ClassMixedWithDSLInstallUtils do
     end
   end
 
+  context '#fetch_promoted_agent_with_fallback' do
+    let(:download_file) { 'puppet-agent-el-8-x86_64.tar.gz' }
+    let(:release_path)  { 'https://pm.puppet.com/v2/agent/2023.8.3/8.11.0/repos' }
+    let(:s3_base)       { 'https://s3.amazonaws.com/puppet-agents/puppet-agent/8.11.0/repos' }
+    let(:agent_dl_base) { 'http://agent-downloads.delivery.puppetlabs.net/puppet-agent/8.11.0/repos' }
+
+    before do
+      # HEAD on the pm.puppet.com URL resolves (via 302) to the S3 promoted mirror.
+      allow(Net::HTTP).to receive(:start).with('pm.puppet.com')
+        .and_return("#{s3_base}/#{download_file}")
+    end
+
+    it 'fetches from the primary mirror when the package is present' do
+      expect(subject).to receive(:fetch_http_file)
+        .with(s3_base, download_file, 'tmp/repo_configs/el')
+      expect(subject).not_to receive(:fetch_http_file)
+        .with(a_string_including('agent-downloads'), anything, anything)
+
+      subject.fetch_promoted_agent_with_fallback(release_path, '', download_file, 'tmp/repo_configs/el', '8.11.0')
+    end
+
+    it 'falls back to agent-downloads on a 404' do
+      allow(subject).to receive(:fetch_http_file)
+        .with(s3_base, download_file, 'tmp/repo_configs/el')
+        .and_raise("Failed to fetch_remote_file '#{s3_base}/#{download_file}' (404 Not Found)")
+      expect(subject).to receive(:fetch_http_file)
+        .with(agent_dl_base, download_file, 'tmp/repo_configs/el')
+
+      subject.fetch_promoted_agent_with_fallback(release_path, '', download_file, 'tmp/repo_configs/el', '8.11.0')
+    end
+
+    it 're-raises non-404 fetch errors without falling back' do
+      allow(subject).to receive(:fetch_http_file)
+        .with(s3_base, download_file, 'tmp/repo_configs/el')
+        .and_raise('Failed to fetch_remote_file (500 Server Error)')
+      expect(subject).not_to receive(:fetch_http_file)
+        .with(a_string_including('agent-downloads'), anything, anything)
+
+      expect {
+        subject.fetch_promoted_agent_with_fallback(release_path, '', download_file, 'tmp/repo_configs/el', '8.11.0')
+      }.to raise_error(/500/)
+    end
+
+    it 'preserves the /windows suffix in the fallback URL' do
+      win_file         = 'puppet-agent-x64.msi'
+      win_release_path = 'https://pm.puppet.com/v2/agent/2023.8.3/8.11.0/repos/windows'
+      win_s3_base      = "#{s3_base}/windows"
+      win_dl_base      = "#{agent_dl_base}/windows"
+      allow(Net::HTTP).to receive(:start).with('pm.puppet.com')
+        .and_return("#{win_s3_base}/#{win_file}")
+      allow(subject).to receive(:fetch_http_file)
+        .with(win_s3_base, win_file, 'tmp/repo_configs/windows')
+        .and_raise("Failed to fetch_remote_file '#{win_s3_base}/#{win_file}' (404 Not Found)")
+      expect(subject).to receive(:fetch_http_file)
+        .with(win_dl_base, win_file, 'tmp/repo_configs/windows')
+
+      subject.fetch_promoted_agent_with_fallback(win_release_path, '/windows', win_file, 'tmp/repo_configs/windows', '8.11.0')
+    end
+  end
+
   context '#prep_host_for_upgrade' do
 
     it 'sets per host options before global options' do


### PR DESCRIPTION
## Summary

When beaker-pe installs a promoted puppet-agent and the package is missing from the public `pm.puppet.com`/S3 mirror (agents ≥ 8.11.0 are no longer published there), fall back to the internal `agent-downloads.delivery.puppetlabs.net` host so the `with-legacy-agents` job passes for both agent streams.

## Changes

- **Extract `AGENT_DOWNLOADS_URL` constant** — promotes the internal host URL (already hardcoded in the sles-11 / solaris-10-sparc paths via `agent_package_common_vars`) to a shared module constant. Pure refactor, no behavior change.
- **Add `fetch_promoted_agent_with_fallback` helper** and wire it into `install_puppet_agent_pe_promoted_repo_on`. The primary fetch path (pm.puppet.com/S3, with HEAD-redirect resolution) is unchanged; on a `404` it falls back to `<AGENT_DOWNLOADS_URL>/<agent_version>/repos<release_path_end>`. Any non-404 error is re-raised unchanged.

## Behavior guarantees

- Versions still present on the public mirror are unaffected — the primary path is byte-for-byte equivalent to before.
- Fallback fires **only** on a `404`.
- The `/windows` suffix is preserved in the fallback URL.

## Testing

- `bundle exec rspec spec/beaker-pe/install/pe_utils_spec.rb` — 230 examples, 0 failures.
- New coverage: primary-mirror present, 404 fallback, non-404 re-raise, `/windows` suffix. Existing redirect test still passes unchanged.

## Follow-up (post-merge)

Re-run `enterprise_pe-acceptance-tests_integration-system_pe_with-legacy-agents_nightly_2025.11.1-release` and confirm both streams (`2023.8.0:8.8.1`, `2023.8.3:8.11.0`) pass on the redhat8 and windows2019 layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)