### PR TITLE
(maint) prepare for release 3.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [3.6.4](https://github.com/puppetlabs/beaker-pe/tree/3.6.4) (2026-07-23)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-pe/compare/3.6.3...3.6.4)
+
+**Fixed bugs:**
+
+- \[PE-41009\]: Fall back to agent-downloads when promoted agent is missing from the public mirror [\#306](https://github.com/puppetlabs/beaker-pe/pull/306) ([Magisus](https://github.com/Magisus))
+
+## [3.6.3](https://github.com/puppetlabs/beaker-pe/tree/3.6.3) (2026-07-16)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-pe/compare/3.6.2...3.6.3)
+
+**Fixed bugs:**
+
+- \[PE-45082\]: Broaden is\_expected\_pe\_postgres\_failure? allowlist [\#303](https://github.com/puppetlabs/beaker-pe/pull/303) ([steveax](https://github.com/steveax))
+
+## [3.6.2](https://github.com/puppetlabs/beaker-pe/tree/3.6.2) (2026-06-05)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-pe/compare/3.6.1...3.6.2)
+
+**Fixed bugs:**
+
+- Add waitforlock flag to second puppet runs to prevent lock collisions [\#300](https://github.com/puppetlabs/beaker-pe/pull/300) ([jonathannewman](https://github.com/jonathannewman))
+
 ## [3.6.1](https://github.com/puppetlabs/beaker-pe/tree/3.6.1) (2025-11-21)
 
 [Full Changelog](https://github.com/puppetlabs/beaker-pe/compare/3.6.0...3.6.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 **Fixed bugs:**
 
-- \[PE-41009\]: Fall back to agent-downloads when promoted agent is missing from the public mirror [\#306](https://github.com/puppetlabs/beaker-pe/pull/306) ([Magisus](https://github.com/Magisus))
+- [PE-41009]: Fall back to agent-downloads when promoted agent is missing from the public mirror [#306](https://github.com/puppetlabs/beaker-pe/pull/306) ([Magisus](https://github.com/Magisus))
 
 ## [3.6.3](https://github.com/puppetlabs/beaker-pe/tree/3.6.3) (2026-07-16)
 
@@ -14,7 +14,7 @@
 
 **Fixed bugs:**
 
-- \[PE-45082\]: Broaden is\_expected\_pe\_postgres\_failure? allowlist [\#303](https://github.com/puppetlabs/beaker-pe/pull/303) ([steveax](https://github.com/steveax))
+- [PE-45082]: Broaden is_expected_pe_postgres_failure? allowlist [#303](https://github.com/puppetlabs/beaker-pe/pull/303) ([steveax](https://github.com/steveax))
 
 ## [3.6.2](https://github.com/puppetlabs/beaker-pe/tree/3.6.2) (2026-06-05)
 
@@ -22,7 +22,7 @@
 
 **Fixed bugs:**
 
-- Add waitforlock flag to second puppet runs to prevent lock collisions [\#300](https://github.com/puppetlabs/beaker-pe/pull/300) ([jonathannewman](https://github.com/jonathannewman))
+- Add waitforlock flag to second puppet runs to prevent lock collisions [#300](https://github.com/puppetlabs/beaker-pe/pull/300) ([jonathannewman](https://github.com/jonathannewman))
 
 ## [3.6.1](https://github.com/puppetlabs/beaker-pe/tree/3.6.1) (2025-11-21)
 

--- a/lib/beaker-pe/version.rb
+++ b/lib/beaker-pe/version.rb
@@ -3,7 +3,7 @@ module Beaker
     module PE
 
       module Version
-        STRING = '3.6.3'
+        STRING = '3.6.4'
       end
 
     end


### PR DESCRIPTION
## Summary

Prepares the 3.6.4 release.

- Bumps the version from `3.6.3` to `3.6.4`
- Backfills the changelog with the 3.6.2 and 3.6.3 releases
- Adds the 3.6.4 section for the agent-downloads fallback change

## Changelog

- **3.6.4** — [#306](https://github.com/puppetlabs/beaker-pe/pull/306) (PE-41009) Fall back to agent-downloads when the promoted agent is missing from the public mirror
- **3.6.3** — [#303](https://github.com/puppetlabs/beaker-pe/pull/303) (PE-45082) Broaden `is_expected_pe_postgres_failure?` allowlist
- **3.6.2** — [#300](https://github.com/puppetlabs/beaker-pe/pull/300) Add waitforlock flag to second puppet runs to prevent lock collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)