### PR TITLE
(PE-45366) Add pe_run_in_parallel option, serial by default on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,27 @@ of key concepts.
 involved in addressing key problems and use-cases. For instance, checkout our
 [How-to Install Puppet Enterprise doc](docs/how_to/install_puppet_enterprise.md).
 
+## Configuration
+
+### Running install/upgrade steps serially (`pe_run_in_parallel`)
+
+Several PE install/upgrade steps act on many hosts at once by `fork()`ing a child
+process per host, each with its own SSH connection. **On macOS, forking a Ruby
+process that has already used `Net::SSH` deadlocks the child**, so these steps hang
+until beaker's watchdog kills them (`RuntimeError: Child process ran longer than
+timeout of 1800`). This does not happen on Linux/CI.
+
+Because of this, beaker-pe defaults to running these steps **serially on macOS** and
+**in parallel on every other platform**. You can override the default either way:
+
+- Option: set `pe_run_in_parallel: true` (or `false`) in your beaker options.
+- Env var: `export BEAKER_PE_RUN_IN_PARALLEL=1` (or `0`) before running beaker.
+
+Precedence, highest first: the `BEAKER_PE_RUN_IN_PARALLEL` env var, then the
+`pe_run_in_parallel` option, then the platform default (`false` on macOS, `true`
+elsewhere). For the env var, `1`, `true`, or `yes` force parallel; `0`, `false`, or
+`no` force serial.
+
 ## Upgrading from 0.y to 1.y?
 
 If you've used beaker-pe previously (during the 0.y versions), you'll

--- a/lib/beaker-pe/install/pe_utils.rb
+++ b/lib/beaker-pe/install/pe_utils.rb
@@ -1519,12 +1519,27 @@ NOASK
             (host['platform'] =~ /windows-2008r2/ && (!version_is_less(host['pe_ver'], '2016.4.99') && version_is_less(host['pe_ver'], '2016.5.99') && !version_is_less(host['pe_ver'], '3.99')))
         end
 
+        # Whether PE install/upgrade steps that act on many hosts should fork and
+        # run in parallel. Forking + Net::SSH deadlocks on macOS, so the default is
+        # serial there and parallel everywhere else; a developer can override either
+        # way. Precedence, highest first:
+        #   BEAKER_PE_RUN_IN_PARALLEL env var > :pe_run_in_parallel option > default
+        #   (false on macOS, true elsewhere)
+        # @api private
+        # @return [Boolean]
+        def pe_run_in_parallel?
+          env = ENV['BEAKER_PE_RUN_IN_PARALLEL']
+          return %w[1 true yes].include?(env.downcase) unless env.nil? || env.empty?
+          opt = options[:pe_run_in_parallel]
+          opt.nil? ? (RUBY_PLATFORM !~ /darwin/) : !!opt
+        end
+
         # Runs puppet on all nodes, unless they have the roles: master,database,console/dashboard
         # @param [Array<Host>] hosts The sorted hosts to install or upgrade PE on
         def run_puppet_on_non_infrastructure_nodes(all_hosts)
           pe_infrastructure = select_hosts({:roles => ['master', 'compile_master', 'pe_compiler', 'dashboard', 'database']}, all_hosts)
           non_infrastructure = all_hosts.reject{|host| pe_infrastructure.include? host}
-          on non_infrastructure, puppet_agent('-t'), :acceptable_exit_codes => [0,2], :run_in_parallel => true
+          on non_infrastructure, puppet_agent('-t'), :acceptable_exit_codes => [0,2], :run_in_parallel => pe_run_in_parallel?
         end
 
         # Whether or not PE should be managing the puppet service on agents.
@@ -2133,7 +2148,7 @@ EOM
           end
 
           step "Stop agent service on infrastructure nodes" do
-            stop_agent_on(pe_infrastructure, :run_in_parallel => true)
+            stop_agent_on(pe_infrastructure, :run_in_parallel => pe_run_in_parallel?)
           end
 
           # waitforlock in case stopping the agent run after stopping the agent service
@@ -2488,7 +2503,7 @@ EOM
             end
 
              step "Install agents" do
-               block_on(agent_nodes, {:run_in_parallel => true}) do |host|
+               block_on(agent_nodes, {:run_in_parallel => pe_run_in_parallel?}) do |host|
                  install_ca_cert_on(host, opts)
                  on(host, installer_cmd(host, opts))
                end
@@ -2500,13 +2515,13 @@ EOM
              end
 
              step "Stop puppet agents to avoid interfering with tests" do
-               stop_agent_on(agent_nodes, :run_in_parallel => true)
+               stop_agent_on(agent_nodes, :run_in_parallel => pe_run_in_parallel?)
              end
 
              # waitforlock in case stopping the agent run after stopping the agent service
              # takes a little longer than usual
              step "Run puppet on all agent nodes" do
-               block_on(agent_nodes, {:run_in_parallel => true}) do |host|
+               block_on(agent_nodes, {:run_in_parallel => pe_run_in_parallel?}) do |host|
                  on host, puppet_agent("-t #{waitforlock_flag(host)}"), :acceptable_exit_codes => [0,2]
                end
              end

--- a/spec/beaker-pe/install/pe_utils_spec.rb
+++ b/spec/beaker-pe/install/pe_utils_spec.rb
@@ -25,6 +25,17 @@ class ClassMixedWithDSLInstallUtils
 end
 
 describe ClassMixedWithDSLInstallUtils do
+  # Neutralize BEAKER_PE_RUN_IN_PARALLEL and pin RUBY_PLATFORM to a non-macOS value
+  # for every example in this file, so that pre-existing specs asserting the default
+  # (:run_in_parallel => true) are not affected by whatever a developer happens to
+  # have exported in their shell or by running the suite on a Mac (where the default
+  # is serial). Examples that exercise the macOS default stub RUBY_PLATFORM to darwin.
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('BEAKER_PE_RUN_IN_PARALLEL').and_return(nil)
+    stub_const('RUBY_PLATFORM', 'x86_64-linux')
+  end
+
   let(:presets)       { Beaker::Options::Presets.new }
   let(:opts)          { presets.presets.merge(presets.env_vars) }
   let(:basic_hosts)   { make_hosts( { :pe_ver => '3.0',
@@ -612,6 +623,35 @@ describe ClassMixedWithDSLInstallUtils do
     end
   end
 
+  describe '#run_puppet_on_non_infrastructure_nodes parallel wiring' do
+    let(:master)   { make_host('master', :pe_ver => '2016.4', :platform => 'el-7-x86_64', :roles => ['master', 'database', 'dashboard']) }
+    let(:el_agent) { make_host('agent', :pe_ver => '2016.4', :platform => 'el-7-x86_64', :roles => ['frictionless']) }
+
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('BEAKER_PE_RUN_IN_PARALLEL').and_return(nil)
+    end
+
+    it 'passes run_in_parallel => false when the option disables it' do
+      subject.options[:pe_run_in_parallel] = false
+      expect(subject).to receive(:on).with(
+        [el_agent],
+        anything,
+        hash_including(:run_in_parallel => false)
+      ).once
+      subject.run_puppet_on_non_infrastructure_nodes([master, el_agent])
+    end
+
+    it 'passes run_in_parallel => true by default' do
+      expect(subject).to receive(:on).with(
+        [el_agent],
+        anything,
+        hash_including(:run_in_parallel => true)
+      ).once
+      subject.run_puppet_on_non_infrastructure_nodes([master, el_agent])
+    end
+  end
+
   describe 'install_via_msi?' do
     it 'returns true if pe_version is before PE 2016.4.0' do
       the_host = winhost.dup
@@ -659,6 +699,71 @@ describe ClassMixedWithDSLInstallUtils do
       expect(subject.install_via_msi?(the_host)).to eq(false)
     end
 
+  end
+
+  describe '#pe_run_in_parallel?' do
+    before do
+      # Default: pretend the env var is unset unless a specific example sets it.
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('BEAKER_PE_RUN_IN_PARALLEL').and_return(nil)
+    end
+
+    context 'with no option and no env var' do
+      it 'defaults to true off macOS' do
+        stub_const('RUBY_PLATFORM', 'x86_64-linux')
+        expect(subject.send(:pe_run_in_parallel?)).to eq(true)
+      end
+
+      it 'defaults to false on macOS' do
+        stub_const('RUBY_PLATFORM', 'x86_64-darwin21')
+        expect(subject.send(:pe_run_in_parallel?)).to eq(false)
+      end
+    end
+
+    context 'with the :pe_run_in_parallel option' do
+      it 'returns false when the option is false' do
+        subject.options[:pe_run_in_parallel] = false
+        expect(subject.send(:pe_run_in_parallel?)).to eq(false)
+      end
+
+      it 'returns true when the option is true' do
+        subject.options[:pe_run_in_parallel] = true
+        expect(subject.send(:pe_run_in_parallel?)).to eq(true)
+      end
+    end
+
+    context 'with the BEAKER_PE_RUN_IN_PARALLEL env var set' do
+      %w[1 true yes TRUE Yes].each do |truthy|
+        it "returns true for #{truthy.inspect}" do
+          allow(ENV).to receive(:[]).with('BEAKER_PE_RUN_IN_PARALLEL').and_return(truthy)
+          expect(subject.send(:pe_run_in_parallel?)).to eq(true)
+        end
+      end
+
+      %w[0 false no off].each do |falsey|
+        it "returns false for #{falsey.inspect}" do
+          allow(ENV).to receive(:[]).with('BEAKER_PE_RUN_IN_PARALLEL').and_return(falsey)
+          expect(subject.send(:pe_run_in_parallel?)).to eq(false)
+        end
+      end
+
+      it 'overrides the option (env true beats option false)' do
+        subject.options[:pe_run_in_parallel] = false
+        allow(ENV).to receive(:[]).with('BEAKER_PE_RUN_IN_PARALLEL').and_return('1')
+        expect(subject.send(:pe_run_in_parallel?)).to eq(true)
+      end
+
+      it 'overrides the option (env false beats option true)' do
+        subject.options[:pe_run_in_parallel] = true
+        allow(ENV).to receive(:[]).with('BEAKER_PE_RUN_IN_PARALLEL').and_return('0')
+        expect(subject.send(:pe_run_in_parallel?)).to eq(false)
+      end
+
+      it 'falls through to the default when the env var is empty' do
+        allow(ENV).to receive(:[]).with('BEAKER_PE_RUN_IN_PARALLEL').and_return('')
+        expect(subject.send(:pe_run_in_parallel?)).to eq(true)
+      end
+    end
   end
 
   describe 'higgs installer' do


### PR DESCRIPTION
#### What's this PR do?

Adds a `pe_run_in_parallel` switch controlling whether beaker-pe's PE install/upgrade steps fork a child process per host or run serially, and **changes the default to serial on macOS**.

Several install/upgrade steps act on many hosts by `fork()`ing a child per host, each with its own `Net::SSH` connection. On macOS, forking a Ruby process that has already used `Net::SSH` deadlocks the child, so those steps hang until beaker's watchdog kills them after 1800s (`RuntimeError: Child process ran longer than timeout of 1800`). This never reproduces on Linux/CI.

A new private helper `pe_run_in_parallel?` on `PEUtils` resolves a single boolean, precedence highest first:

1. `BEAKER_PE_RUN_IN_PARALLEL` env var (`1`/`true`/`yes` = parallel, `0`/`false`/`no` = serial)
2. `options[:pe_run_in_parallel]` option
3. Default: **`false` on macOS, `true` on every other platform**

The 5 hardcoded `:run_in_parallel => true` literals in `lib/beaker-pe/install/pe_utils.rb` now call the helper. Mac developers get serial execution out of the box, so the deadlock no longer bites; a developer on any platform can override the default either direction via the option or env var.

#### Should any of this be tested outside the normal PR CI cycle?

CI runs on Linux, where the default resolves to `true`, so behavior is byte-for-byte unchanged there. The macOS serial path is exercised by unit specs (the platform default, option, and env var all resolve to `false` and reach the call sites); the underlying deadlock itself only reproduces on a Mac and isn't covered by CI.

#### Any background context you want to provide?

- The default is derived from `RUBY_PLATFORM` (the machine running beaker, which is the process that forks), matching `/darwin/`.
- The spec suite is made hermetic against both a developer's exported `BEAKER_PE_RUN_IN_PARALLEL` and being run on a Mac, by stubbing the env var and `RUBY_PLATFORM` for every example. Pre-existing `:run_in_parallel => true` specs still pass because they run against the pinned non-macOS platform.
- README gains a `## Configuration` section documenting the option, env var, precedence, and the macOS default.
- Labeled `enhancement` for the changelog generator (feature → minor version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
