### PR TITLE
(maint) prepare for release 3.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.6.5](https://github.com/puppetlabs/beaker-pe/tree/3.6.5) (2026-07-29)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-pe/compare/3.6.4...3.6.5)
+
+**Implemented enhancements:**
+
+- (PE-45366) Add pe_run_in_parallel option, serial by default on macOS [#309](https://github.com/puppetlabs/beaker-pe/pull/309) ([Magisus](https://github.com/Magisus))
+
 ## [3.6.4](https://github.com/puppetlabs/beaker-pe/tree/3.6.4) (2026-07-23)
 
 [Full Changelog](https://github.com/puppetlabs/beaker-pe/compare/3.6.3...3.6.4)

--- a/lib/beaker-pe/version.rb
+++ b/lib/beaker-pe/version.rb
@@ -3,7 +3,7 @@ module Beaker
     module PE
 
       module Version
-        STRING = '3.6.4'
+        STRING = '3.6.5'
       end
 
     end


### PR DESCRIPTION
## Summary

Prepare the 3.6.5 patch (Z) release from the current state of `main`.

- Bump version `3.6.4` → `3.6.5` in `lib/beaker-pe/version.rb`
- Add the 3.6.5 CHANGELOG entry

## Changes since 3.6.4

- **Implemented enhancements:**
  - (PE-45366) Add `pe_run_in_parallel` option, serial by default on macOS [#309](https://github.com/puppetlabs/beaker-pe/pull/309) ([Magisus](https://github.com/Magisus))

🤖 Generated with [Claude Code](https://claude.com/claude-code)